### PR TITLE
adapters: Claude Code JSONL reader

### DIFF
--- a/src/adapters/claude.rs
+++ b/src/adapters/claude.rs
@@ -1,0 +1,638 @@
+//! Claude Code transcript adapter.
+//!
+//! Reads JSONL files at ~/.claude/projects/<slug>/<uuid>.jsonl and parses them
+//! into LedgerRow records. Filters non-conversation type rows that the agent
+//! emits for housekeeping (file-history-snapshot, permission-mode,
+//! queue-operation, summary).
+
+use crate::adapters::{Adapter, AdapterError, RawRecord};
+use crate::storage::LedgerRow;
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Non-conversation type filter
+// ---------------------------------------------------------------------------
+
+const NON_CONVERSATION_TYPES: &[&str] = &[
+    "file-history-snapshot",
+    "permission-mode",
+    "queue-operation",
+    "summary",
+];
+
+// ---------------------------------------------------------------------------
+// Cursor
+// ---------------------------------------------------------------------------
+
+/// Read-position cursor for a single Claude transcript file.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ClaudeCursor {
+    /// Path to the JSONL transcript file.
+    pub file_path: PathBuf,
+    /// Byte offset of the first byte NOT yet consumed (exclusive lower bound).
+    pub byte_offset: u64,
+    /// UUID of the last consumed record, used to detect parent-chain regressions.
+    pub last_uuid: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+pub struct ClaudeAdapter {
+    /// Optional override for the projects root, useful in tests. Production
+    /// uses the default ~/.claude/projects/.
+    pub projects_root: Option<PathBuf>,
+}
+
+impl ClaudeAdapter {
+    pub fn new() -> Self {
+        Self {
+            projects_root: None,
+        }
+    }
+
+    /// For tests: override the root to point at a fixture directory or any
+    /// caller-supplied path.
+    pub fn with_projects_root(root: PathBuf) -> Self {
+        Self {
+            projects_root: Some(root),
+        }
+    }
+
+    fn projects_root(&self) -> Result<PathBuf, AdapterError> {
+        if let Some(p) = &self.projects_root {
+            return Ok(p.clone());
+        }
+        let home =
+            dirs::home_dir().ok_or_else(|| AdapterError::PathNotFound(PathBuf::from("$HOME")))?;
+        Ok(home.join(".claude").join("projects"))
+    }
+}
+
+impl Default for ClaudeAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Adapter for ClaudeAdapter {
+    type Cursor = ClaudeCursor;
+
+    fn name(&self) -> &'static str {
+        "claude"
+    }
+
+    /// Detect by checking whether the projects directory exists.
+    fn detect(&self) -> Result<Option<PathBuf>, AdapterError> {
+        let root = self.projects_root()?;
+        if root.exists() {
+            Ok(Some(root))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Read new complete lines from the cursor's file starting at byte_offset.
+    ///
+    /// A partial line at the tail (no trailing `\n`) is NOT consumed — the
+    /// adapter emits `AdapterError::PartialJsonl` with the offset of the
+    /// partial line's first byte. If the file ends exactly on a newline
+    /// boundary (or is empty past the cursor), returns normally with an
+    /// empty-or-populated vec and an advanced cursor.
+    fn read_new_records(
+        &self,
+        since: &Self::Cursor,
+    ) -> Result<(Vec<RawRecord>, Self::Cursor), AdapterError> {
+        let file_path = &since.file_path;
+
+        // Empty path means nothing has been configured yet — return empty.
+        if file_path.as_os_str().is_empty() {
+            return Ok((
+                vec![],
+                ClaudeCursor {
+                    file_path: file_path.clone(),
+                    byte_offset: 0,
+                    last_uuid: since.last_uuid.clone(),
+                },
+            ));
+        }
+
+        // Containment + symlink guard: `cursor.file_path` is persisted to the
+        // SQLite cursors table and could be tampered with. Without this check
+        // a tampered cursor turns the adapter into an arbitrary-file-read
+        // primitive (e.g. /etc/shadow, ~/.ssh/id_rsa). canonicalize() resolves
+        // symlinks before the prefix check, closing symlink-escape as well.
+        let root = self.projects_root()?;
+        let canonical_root = root
+            .canonicalize()
+            .map_err(|_| AdapterError::PathNotFound(root.clone()))?;
+        let canonical_file = file_path
+            .canonicalize()
+            .map_err(|_| AdapterError::PathNotFound(file_path.clone()))?;
+        if !canonical_file.starts_with(&canonical_root) {
+            return Err(AdapterError::PathNotFound(file_path.clone()));
+        }
+
+        let (line_records, new_offset) =
+            read_complete_lines(file_path, since.byte_offset, self.name())?;
+
+        let records: Vec<RawRecord> = line_records
+            .into_iter()
+            .map(|(end_offset, bytes)| RawRecord {
+                tool: self.name().to_string(),
+                payload: bytes,
+                offset: end_offset,
+            })
+            .collect();
+
+        let last_uuid = records
+            .iter()
+            .rev()
+            .find_map(|r| extract_uuid_from_payload(&r.payload))
+            .or_else(|| since.last_uuid.clone());
+
+        let advanced = ClaudeCursor {
+            file_path: file_path.clone(),
+            byte_offset: new_offset,
+            last_uuid,
+        };
+
+        Ok((records, advanced))
+    }
+
+    /// Parse raw records into LedgerRow. Skips non-conversation types.
+    /// Fail-fast: first malformed record aborts the batch.
+    fn parse(&self, records: Vec<RawRecord>) -> Result<Vec<LedgerRow>, AdapterError> {
+        let mut rows = Vec::with_capacity(records.len());
+
+        for rec in records {
+            let v: serde_json::Value =
+                serde_json::from_slice(&rec.payload).map_err(|e| AdapterError::Parse {
+                    offset: rec.offset,
+                    context: "invalid JSON in transcript line",
+                    source: e,
+                })?;
+
+            // Filter housekeeping rows.
+            let row_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            if NON_CONVERSATION_TYPES.contains(&row_type) {
+                continue;
+            }
+
+            // Required: sessionId
+            let session_id = v
+                .get("sessionId")
+                .and_then(|s| s.as_str())
+                .ok_or_else(|| AdapterError::Parse {
+                    offset: rec.offset,
+                    context: "missing sessionId field",
+                    source: make_missing_field_error(),
+                })?
+                .to_string();
+
+            // Required: ts (unix epoch ms as i64)
+            let ts = parse_timestamp(v.get("ts"), rec.offset)?;
+
+            // Required: role (fall back to type if role absent)
+            let role = v
+                .get("role")
+                .and_then(|r| r.as_str())
+                .or_else(|| v.get("type").and_then(|t| t.as_str()))
+                .ok_or_else(|| AdapterError::Parse {
+                    offset: rec.offset,
+                    context: "missing role and type fields",
+                    source: make_missing_field_error(),
+                })?
+                .to_string();
+
+            // content: string or array
+            let content_val = v.get("content");
+            let content = match content_val {
+                None => String::new(),
+                Some(serde_json::Value::String(s)) => s.clone(),
+                Some(arr) => serde_json::to_string(arr).map_err(|e| AdapterError::Parse {
+                    offset: rec.offset,
+                    context: "failed to serialize content array",
+                    source: e,
+                })?,
+            };
+
+            let tool_calls_json = extract_tool_calls(content_val);
+            let files_touched_json = extract_files_touched(content_val);
+            let parent_id = v
+                .get("parentUuid")
+                .and_then(|p| p.as_str())
+                .map(|s| s.to_string());
+
+            rows.push(LedgerRow {
+                session_id,
+                tool: "claude".to_string(),
+                ts,
+                role,
+                content,
+                tool_calls_json,
+                files_touched_json,
+                parent_id,
+            });
+        }
+
+        Ok(rows)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// `(end_offset_exclusive, line_bytes_including_newline)` pairs from a file read.
+type LineRecords = Vec<(u64, Vec<u8>)>;
+
+/// Per-poll read cap. A single `read_new_records` call will never allocate
+/// more than this many bytes of transcript into RAM, even if the file has
+/// grown by gigabytes since the last cursor advance. Lines longer than this
+/// surface as `AdapterError::PartialJsonl` (or get split across polls if the
+/// writer eventually closes the line).
+const MAX_READ_BYTES_PER_POLL: u64 = 64 * 1024 * 1024;
+
+/// Read all complete (newline-terminated) lines from `file_path` starting at
+/// `from_offset`. Returns `(records, new_offset)` where each record is
+/// `(end_offset_exclusive, line_bytes_including_newline)`.
+///
+/// If a partial line (bytes without a trailing `\n`) is detected at the tail,
+/// returns `AdapterError::PartialJsonl` with the offset of the partial line's
+/// first byte. The partial bytes are not included in records.
+fn read_complete_lines(
+    file_path: &Path,
+    from_offset: u64,
+    tool: &str,
+) -> Result<(LineRecords, u64), AdapterError> {
+    let mut file = std::fs::File::open(file_path)?;
+    file.seek(SeekFrom::Start(from_offset))?;
+
+    let mut buf = Vec::new();
+    file.take(MAX_READ_BYTES_PER_POLL).read_to_end(&mut buf)?;
+
+    if buf.is_empty() {
+        return Ok((vec![], from_offset));
+    }
+
+    let mut records = Vec::new();
+    let mut cursor = 0usize;
+    let mut byte_pos = from_offset;
+
+    while cursor < buf.len() {
+        match buf[cursor..].iter().position(|&b| b == b'\n') {
+            Some(nl_rel) => {
+                let line_end = cursor + nl_rel + 1; // include the '\n'
+                let line = buf[cursor..line_end].to_vec();
+                byte_pos += line.len() as u64;
+                records.push((byte_pos, line));
+                cursor = line_end;
+            }
+            None => {
+                // Remaining bytes form a partial line — no trailing newline.
+                let partial_offset = from_offset + cursor as u64;
+                // Build a minimal serde_json::Error to satisfy the type.
+                // We use from_str on truncated JSON to get a real parse error
+                // that reflects the partial content.
+                let partial_bytes = &buf[cursor..];
+                // Manufacture a serde_json::Error from the partial slice. If
+                // the slice somehow parses successfully (only possible on
+                // pathological inputs that happen to be a valid JSON value
+                // without a trailing newline), fall back to the helper error
+                // so we never panic via .unwrap_err().
+                let partial_err = serde_json::from_slice::<serde_json::Value>(partial_bytes)
+                    .err()
+                    .unwrap_or_else(make_missing_field_error);
+                // Suppress unused variable warning — tool is passed for
+                // potential future structured logging but not needed for the
+                // error value itself.
+                let _ = tool;
+                return Err(AdapterError::PartialJsonl {
+                    offset: partial_offset,
+                    source: partial_err,
+                });
+            }
+        }
+    }
+
+    Ok((records, byte_pos))
+}
+
+/// Parse the `ts` field. Fixtures use unix epoch milliseconds (i64).
+fn parse_timestamp(val: Option<&serde_json::Value>, offset: u64) -> Result<i64, AdapterError> {
+    match val {
+        Some(serde_json::Value::Number(n)) => n.as_i64().ok_or_else(|| AdapterError::Parse {
+            offset,
+            context: "ts field is not a valid i64",
+            source: make_missing_field_error(),
+        }),
+        Some(serde_json::Value::String(_s)) => {
+            // ISO-8601 is not used in any current fixture; parse as integer
+            // string as a best-effort fallback.
+            _s.parse::<i64>().map_err(|_| AdapterError::Parse {
+                offset,
+                context: "ts field string is not parseable as i64",
+                source: make_missing_field_error(),
+            })
+        }
+        _ => Err(AdapterError::Parse {
+            offset,
+            context: "missing or non-numeric ts field",
+            source: make_missing_field_error(),
+        }),
+    }
+}
+
+/// Extract `tool_use` entries from a content array.
+/// Returns JSON-serialized array of tool_use blocks, or None if there are none.
+fn extract_tool_calls(content: Option<&serde_json::Value>) -> Option<String> {
+    let arr = content?.as_array()?;
+    let tool_uses: Vec<&serde_json::Value> = arr
+        .iter()
+        .filter(|item| {
+            item.get("type")
+                .and_then(|t| t.as_str())
+                .map(|t| t == "tool_use")
+                .unwrap_or(false)
+        })
+        .collect();
+
+    if tool_uses.is_empty() {
+        return None;
+    }
+
+    serde_json::to_string(&tool_uses).ok()
+}
+
+/// Extract file paths from tool_use `input.path` fields within a content array.
+/// Returns JSON-serialized array of path strings, or None if none found.
+fn extract_files_touched(content: Option<&serde_json::Value>) -> Option<String> {
+    let arr = content?.as_array()?;
+    let paths: Vec<&str> = arr
+        .iter()
+        .filter(|item| {
+            item.get("type")
+                .and_then(|t| t.as_str())
+                .map(|t| t == "tool_use")
+                .unwrap_or(false)
+        })
+        .filter_map(|item| {
+            item.get("input")
+                .and_then(|inp| inp.get("path"))
+                .and_then(|p| p.as_str())
+        })
+        .collect();
+
+    if paths.is_empty() {
+        return None;
+    }
+
+    serde_json::to_string(&paths).ok()
+}
+
+/// Extract the UUID from a raw payload without full deserialization.
+fn extract_uuid_from_payload(payload: &[u8]) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_slice(payload).ok()?;
+    v.get("uuid")?.as_str().map(|s| s.to_string())
+}
+
+/// Produce a synthetic `serde_json::Error` for use in `AdapterError::Parse`
+/// where the true error is a missing field rather than a JSON syntax error.
+fn make_missing_field_error() -> serde_json::Error {
+    serde_json::from_str::<serde_json::Value>("").unwrap_err()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::Adapter;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/claude"
+        ))
+        .join(name)
+    }
+
+    fn fixture_root() -> PathBuf {
+        PathBuf::from(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/claude"
+        ))
+    }
+
+    /// Build an adapter whose `projects_root` is the fixture directory, so
+    /// the containment check in `read_new_records` accepts cursor paths to
+    /// the fixture files.
+    fn adapter() -> ClaudeAdapter {
+        ClaudeAdapter::with_projects_root(fixture_root())
+    }
+
+    fn cursor_for(name: &str) -> ClaudeCursor {
+        ClaudeCursor {
+            file_path: fixture_path(name),
+            byte_offset: 0,
+            last_uuid: None,
+        }
+    }
+
+    // 1. Happy-path: 3 conversation rows, roles preserved.
+    #[test]
+    fn parses_simple_conversation() {
+        let a = adapter();
+        let (records, _cursor) = a
+            .read_new_records(&cursor_for("1-simple-conversation.jsonl"))
+            .unwrap();
+        let rows = a.parse(records).unwrap();
+
+        assert_eq!(rows.len(), 3, "expected 3 LedgerRows");
+        assert_eq!(rows[0].role, "user");
+        assert_eq!(rows[1].role, "assistant");
+        assert_eq!(rows[2].role, "user");
+
+        // All belong to the same session.
+        for row in &rows {
+            assert_eq!(row.session_id, "session-simple-001");
+            assert_eq!(row.tool, "claude");
+        }
+    }
+
+    // 2. Parent chain: every row's parent_id matches the previous uuid.
+    #[test]
+    fn preserves_parent_chain() {
+        let a = adapter();
+        let (records, _) = a
+            .read_new_records(&cursor_for("2-parentuuid-chain-deep.jsonl"))
+            .unwrap();
+        let rows = a.parse(records).unwrap();
+
+        assert!(
+            rows.len() >= 3,
+            "need at least 3 rows to verify chain depth >=2"
+        );
+
+        // Row 0 is root — no parent.
+        assert!(
+            rows[0].parent_id.is_none(),
+            "root row must have no parent_id"
+        );
+
+        // Rows 1..n each have a non-None parent_id.
+        for (i, row) in rows.iter().enumerate().skip(1) {
+            assert!(row.parent_id.is_some(), "row {} must have a parent_id", i);
+        }
+
+        // Verify chain: rows[1].parent_id == rows[0]'s uuid
+        // We read the uuid directly from fixture JSON to cross-check.
+        let raw_lines =
+            std::fs::read_to_string(fixture_path("2-parentuuid-chain-deep.jsonl")).unwrap();
+        let values: Vec<serde_json::Value> = raw_lines
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+
+        for (i, row) in rows.iter().enumerate().skip(1) {
+            let expected_parent = values[i]
+                .get("parentUuid")
+                .and_then(|p| p.as_str())
+                .unwrap();
+            assert_eq!(
+                row.parent_id.as_deref(),
+                Some(expected_parent),
+                "row {} parent_id mismatch",
+                i
+            );
+        }
+    }
+
+    // 3. Tool use: tool_calls_json populated; files_touched_json has paths.
+    #[test]
+    fn extracts_tool_use_and_result() {
+        let a = adapter();
+        let (records, _) = a
+            .read_new_records(&cursor_for("3-tool-use-and-result.jsonl"))
+            .unwrap();
+        let rows = a.parse(records).unwrap();
+
+        // Row 1 (index 1) is the first assistant turn with a tool_use block.
+        let tool_use_row = rows
+            .iter()
+            .find(|r| r.tool_calls_json.is_some())
+            .expect("at least one row must have tool_calls_json");
+
+        assert!(tool_use_row.tool_calls_json.is_some());
+        assert!(
+            tool_use_row.files_touched_json.is_some(),
+            "tool_use row with path must have files_touched_json"
+        );
+
+        // Sanity: the path appears in files_touched_json.
+        let files = tool_use_row.files_touched_json.as_ref().unwrap();
+        assert!(
+            files.contains("/synthetic/path/1/main.rs"),
+            "expected path in files_touched_json, got: {}",
+            files
+        );
+    }
+
+    // 4. Non-conversation types are filtered out.
+    #[test]
+    fn filters_non_conversation_types() {
+        let a = adapter();
+        let (records, _) = a
+            .read_new_records(&cursor_for("4-non-conversation-types.jsonl"))
+            .unwrap();
+        let total = records.len();
+        let rows = a.parse(records).unwrap();
+
+        // Fixture has 9 lines: 5 "say" + 4 housekeeping.
+        assert_eq!(total, 9, "expected 9 raw records");
+        assert_eq!(
+            rows.len(),
+            5,
+            "expected 5 conversation rows after filtering"
+        );
+
+        // Every surviving row must have role user or assistant.
+        for row in &rows {
+            assert!(
+                row.role == "user" || row.role == "assistant",
+                "unexpected role: {}",
+                row.role
+            );
+        }
+    }
+
+    // 5. Partial tail emits PartialJsonl with the correct offset.
+    #[test]
+    fn partial_line_tail_returns_error_with_offset() {
+        let a = adapter();
+        let cursor = cursor_for("5-partial-line-tail.jsonl");
+        let err = a.read_new_records(&cursor).unwrap_err();
+
+        match err {
+            AdapterError::PartialJsonl { offset, .. } => {
+                assert_eq!(
+                    offset, 798,
+                    "partial line must start at byte 798, got {}",
+                    offset
+                );
+            }
+            other => panic!("expected AdapterError::PartialJsonl, got {:?}", other),
+        }
+    }
+
+    // 6. Cursor is monotonic across two reads on a stable file (using fixture 1).
+    #[test]
+    fn cursor_monotonic_across_reads() {
+        // Use a file with only complete lines so first read succeeds.
+        let a = adapter();
+        let cursor0 = cursor_for("1-simple-conversation.jsonl");
+        let (records1, cursor1) = a.read_new_records(&cursor0).unwrap();
+        assert!(!records1.is_empty(), "first read should return records");
+        assert!(
+            cursor1.byte_offset >= cursor0.byte_offset,
+            "cursor must not regress"
+        );
+
+        // Second read from advanced cursor must return nothing new.
+        let (records2, cursor2) = a.read_new_records(&cursor1).unwrap();
+        assert!(records2.is_empty(), "no new records on second read");
+        assert_eq!(
+            cursor2.byte_offset, cursor1.byte_offset,
+            "cursor must be stable"
+        );
+    }
+
+    // 7. detect() returns Some when projects root exists.
+    #[test]
+    fn detect_returns_root_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = ClaudeAdapter::with_projects_root(dir.path().to_path_buf());
+        let result = a.detect().unwrap();
+        assert!(result.is_some(), "detect must return Some when dir exists");
+        assert_eq!(result.unwrap(), dir.path());
+    }
+
+    // 8. detect() returns None when projects root does not exist.
+    #[test]
+    fn detect_returns_none_when_absent() {
+        let a = ClaudeAdapter::with_projects_root(PathBuf::from(
+            "/tmp/carryover-test-nonexistent-dir-xyz-987654",
+        ));
+        let result = a.detect().unwrap();
+        assert!(
+            result.is_none(),
+            "detect must return None when dir is absent"
+        );
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -152,14 +152,14 @@ pub trait Adapter: Send + Sync {
 /// (de)serializing cursors as JSON strings. The daemon worker stores cursors
 /// in the `cursors` SQLite table as JSON blobs anyway, so the erasure is free.
 ///
-/// TODO: real adapter variants (`Claude`, `Cursor`, `Codex`) land in the
-/// follow-up adapter PRs and slot into the `match` arms below. Marked
-/// `#[non_exhaustive]` so adding those variants is non-breaking for any
+/// Marked `#[non_exhaustive]` so adding variants is non-breaking for any
 /// future external `match` site.
 #[non_exhaustive]
 pub enum AdapterKind {
     /// In-memory adapter for tests and pre-adapter scaffolding.
     Mock(mock::MockAdapter),
+    /// Claude Code transcript adapter.
+    Claude(claude::ClaudeAdapter),
 }
 
 impl AdapterKind {
@@ -167,6 +167,7 @@ impl AdapterKind {
     pub fn name(&self) -> &'static str {
         match self {
             AdapterKind::Mock(a) => a.name(),
+            AdapterKind::Claude(a) => a.name(),
         }
     }
 
@@ -174,6 +175,7 @@ impl AdapterKind {
     pub fn detect(&self) -> Result<Option<PathBuf>, AdapterError> {
         match self {
             AdapterKind::Mock(a) => a.detect(),
+            AdapterKind::Claude(a) => a.detect(),
         }
     }
 
@@ -196,6 +198,16 @@ impl AdapterKind {
                 let advanced_json = serde_json::to_string(&advanced)?;
                 Ok((records, advanced_json))
             }
+            AdapterKind::Claude(a) => {
+                let cursor: <claude::ClaudeAdapter as Adapter>::Cursor = if since_json.is_empty() {
+                    Default::default()
+                } else {
+                    serde_json::from_str(since_json)?
+                };
+                let (records, advanced) = a.read_new_records(&cursor)?;
+                let advanced_json = serde_json::to_string(&advanced)?;
+                Ok((records, advanced_json))
+            }
         }
     }
 
@@ -207,9 +219,16 @@ impl AdapterKind {
     ) -> Result<Vec<crate::storage::LedgerRow>, AdapterError> {
         match self {
             AdapterKind::Mock(a) => a.parse(records),
+            AdapterKind::Claude(a) => a.parse(records),
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Adapters
+// ---------------------------------------------------------------------------
+
+pub mod claude;
 
 // ---------------------------------------------------------------------------
 // Mock adapter
@@ -495,5 +514,12 @@ mod tests {
         let json = serde_json::to_string(&cursor).unwrap();
         let restored: MockCursor = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.offset, cursor.offset);
+    }
+
+    #[test]
+    fn adapter_kind_dispatches_claude() {
+        let a = claude::ClaudeAdapter::new();
+        let kind = AdapterKind::Claude(a);
+        assert_eq!(kind.name(), "claude");
     }
 }


### PR DESCRIPTION
First adapter implementation. Parses transcripts from `~/.claude/projects/<slug>/<uuid>.jsonl` into the unified `LedgerRow` schema.

What this introduces:
- `ClaudeAdapter` implementing the `Adapter` trait with `ClaudeCursor { file_path, byte_offset, last_uuid }`
- Cursor persists to the SQLite cursors table; advances only past newline-terminated lines so partial tails are never lost
- `AdapterError::PartialJsonl` returned with the byte offset of the truncated line (verified at offset 798 against fixture #5)
- Filters non-conversation rows (`file-history-snapshot`, `permission-mode`, `queue-operation`, `summary`) before parsing
- Preserves `parentUuid` as `LedgerRow.parent_id`; serializes content arrays; extracts `tool_use` blocks into `tool_calls_json` and any `input.path` values into `files_touched_json`
- Containment check: cursor `file_path` is canonicalized and must live inside `projects_root` before the file is opened — closes the arbitrary-file-read vector a tampered cursor row could otherwise create
- 64 MiB per-poll read cap so an unbounded-line transcript cannot exhaust memory
- `AdapterKind::Claude` variant + dispatch through `name`, `detect`, `read_new_records_erased`, `parse`
- 9 tests against the shipped fixture corpus

Test plan:
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (34 passed: 31 unit + 3 integration)
- [x] cargo-deny check (advisories + bans + licenses + sources all ok)
- [x] Containment check rejects cursor paths outside projects_root
- [x] Partial-tail returns PartialJsonl with correct byte offset