### PR TITLE
distill: three always-on extractors (task / open_questions / next_action)

### DIFF
--- a/src/distill/mod.rs
+++ b/src/distill/mod.rs
@@ -1,5 +1,15 @@
-//! Distillation pipeline: 3 always-on extractors (task, open_questions, next_action)
-//! + 3 coding-only (recent_files, failed_approaches, git_context).
+//! Distillation pipeline: pure-code extractors that turn LedgerRow batches
+//! into the components of the 50-line handoff payload.
 //!
-//! 50-line cap on output. No LLM tokens consumed; all extraction is rule-based.
-//! See ARCHITECTURE.md for extractor contract and RELEASE_ROADMAP.md for v0.1 scope.
+//! Always-on extractors (this PR):
+//! - task: condenses the latest user prompt into one line
+//! - open_questions: detects unresolved decisions/TODOs across the session
+//! - next_action: extracts the final actionable instruction
+//!
+//! Coding-only extractors (recent_files / failed_approaches / git_context)
+//! ship in a follow-up PR; they activate only when the session contains
+//! tool_use rows.
+
+pub mod next_action;
+pub mod open_questions;
+pub mod task;

--- a/src/distill/next_action.rs
+++ b/src/distill/next_action.rs
@@ -1,0 +1,283 @@
+//! `next_action` extractor — pulls the final actionable sentence from the
+//! latest assistant turn.
+
+use crate::storage::LedgerRow;
+
+pub const MAX_NEXT_ACTION_CHARS: usize = 120;
+pub const NO_NEXT_ACTION_SENTINEL: &str = "<no next action captured>";
+
+/// Extract the final actionable sentence from the latest assistant turn.
+///
+/// Algorithm:
+/// 1. Iterate rows in reverse; find the most recent `role == "assistant"` row
+///    with non-empty content.
+/// 2. Strip Markdown code fences (lines starting with ` ``` ` and all lines
+///    they enclose).
+/// 3. Strip Markdown bullet markers (`-`, `*`, `+`, `1.` etc.) at line starts.
+/// 4. Find the last non-empty sentence (split on `.`, `!`, `?` followed by
+///    space or end-of-string).
+/// 5. Truncate to `MAX_NEXT_ACTION_CHARS` at word boundary if needed.
+/// 6. Return the sentence, or `NO_NEXT_ACTION_SENTINEL` if no assistant row
+///    exists.
+pub fn extract_next_action(rows: &[LedgerRow]) -> String {
+    for row in rows.iter().rev() {
+        if row.role != "assistant" {
+            continue;
+        }
+        let trimmed = row.content.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let stripped = strip_code_fences(trimmed);
+        let cleaned = strip_bullet_prefixes(&stripped);
+        let text = cleaned.trim();
+
+        if text.is_empty() {
+            continue;
+        }
+
+        if let Some(sentence) = last_sentence(text) {
+            return truncate_at_word(&sentence, MAX_NEXT_ACTION_CHARS);
+        }
+    }
+    NO_NEXT_ACTION_SENTINEL.to_string()
+}
+
+/// Remove Markdown code-fence blocks. Lines that start with ` ``` ` (ignoring
+/// leading whitespace) toggle an "inside fence" state; all lines inside (and
+/// the fence lines themselves) are dropped.
+///
+/// If the input contains an unclosed fence (toggled-on but no matching close),
+/// the fenced lines are NOT silently dropped — they are restored at end of
+/// scan and treated as prose. Without this guard a malformed assistant turn
+/// could lose all its actionable content to a stray triple-backtick.
+fn strip_code_fences(text: &str) -> String {
+    let mut result: Vec<&str> = Vec::new();
+    let mut buffered: Vec<&str> = Vec::new();
+    let mut inside_fence = false;
+
+    for line in text.lines() {
+        let ltrimmed = line.trim_start();
+        if ltrimmed.starts_with("```") {
+            if inside_fence {
+                // Closing the fence — discard the buffered lines (real fence).
+                buffered.clear();
+            }
+            inside_fence = !inside_fence;
+            // Drop the fence line itself either way.
+            continue;
+        }
+        if inside_fence {
+            buffered.push(line);
+        } else {
+            result.push(line);
+        }
+    }
+    // Unclosed fence: restore the buffered content as prose.
+    if inside_fence {
+        result.extend(buffered);
+    }
+    result.join("\n")
+}
+
+/// Strip common Markdown bullet/list prefixes from the start of each line.
+/// Handles `-`, `*`, `+` (with optional space) and ordered `1.`, `2.` etc.
+fn strip_bullet_prefixes(text: &str) -> String {
+    let lines: Vec<String> = text
+        .lines()
+        .map(|line| {
+            let t = line.trim_start();
+            // Ordered list: one or more digits followed by `.` and whitespace.
+            if let Some(rest) = strip_ordered_prefix(t) {
+                return rest.to_string();
+            }
+            // Unordered list: `-`, `*`, or `+` followed by whitespace.
+            if let Some(stripped) = t
+                .strip_prefix("- ")
+                .or_else(|| t.strip_prefix("* "))
+                .or_else(|| t.strip_prefix("+ "))
+            {
+                return stripped.to_string();
+            }
+            line.to_string()
+        })
+        .collect();
+    lines.join("\n")
+}
+
+/// If `s` starts with digits followed by `.` and at least one space, return
+/// the remainder after that prefix; otherwise return `None`.
+fn strip_ordered_prefix(s: &str) -> Option<&str> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == 0 {
+        return None;
+    }
+    if bytes.get(i) == Some(&b'.') && bytes.get(i + 1) == Some(&b' ') {
+        Some(&s[i + 2..])
+    } else {
+        None
+    }
+}
+
+/// Split `text` into sentences on `.`, `!`, or `?` followed by a space or
+/// end-of-line/end-of-string. Newlines are also treated as hard sentence
+/// boundaries so that multi-line text is split correctly. The terminator is
+/// kept with the sentence. Returns the last non-empty sentence, or `None` if
+/// the text is empty.
+fn last_sentence(text: &str) -> Option<String> {
+    let mut sentences: Vec<String> = Vec::new();
+
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let chars: Vec<char> = line.chars().collect();
+        let len = chars.len();
+        let mut start = 0usize;
+        let mut i = 0usize;
+
+        while i < len {
+            let c = chars[i];
+            if matches!(c, '.' | '!' | '?') {
+                let next_is_boundary = i + 1 >= len || chars[i + 1].is_whitespace();
+                if next_is_boundary {
+                    let sentence: String = chars[start..=i].iter().collect();
+                    let s = sentence.trim().to_string();
+                    if !s.is_empty() {
+                        sentences.push(s);
+                    }
+                    start = i + 1;
+                    while start < len && chars[start].is_whitespace() {
+                        start += 1;
+                    }
+                    i = start;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+
+        // Remainder of this line (no trailing terminator).
+        if start < len {
+            let remainder: String = chars[start..].iter().collect();
+            let s = remainder.trim().to_string();
+            if !s.is_empty() {
+                sentences.push(s);
+            }
+        }
+    }
+
+    sentences.into_iter().rev().find(|s| !s.is_empty())
+}
+
+/// Truncate `s` to at most `max_chars` characters. If truncation is needed,
+/// cut at the last ASCII whitespace boundary before the cap and append `…`.
+fn truncate_at_word(s: &str, max_chars: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        return s.to_string();
+    }
+    let prefix: String = s.chars().take(max_chars).collect();
+    if let Some(boundary) = prefix.rfind(|c: char| c.is_ascii_whitespace()) {
+        let trimmed = prefix[..boundary].trim_end();
+        format!("{}…", trimmed)
+    } else {
+        format!("{}…", prefix)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_row(role: &str, content: &str) -> LedgerRow {
+        LedgerRow {
+            session_id: "s1".to_string(),
+            tool: "claude".to_string(),
+            ts: 0,
+            role: role.to_string(),
+            content: content.to_string(),
+            tool_calls_json: None,
+            files_touched_json: None,
+            parent_id: None,
+        }
+    }
+
+    #[test]
+    fn extracts_final_sentence_of_latest_assistant_turn() {
+        let rows = vec![make_row("assistant", "I did X. Now run Y.")];
+        assert_eq!(extract_next_action(&rows), "Now run Y.");
+    }
+
+    #[test]
+    fn strips_code_fences() {
+        let content = "Here is the code:\n```\nlet x = 1;\n```\nNow compile it.";
+        let rows = vec![make_row("assistant", content)];
+        let result = extract_next_action(&rows);
+        assert_eq!(result, "Now compile it.");
+    }
+
+    #[test]
+    fn handles_question_mark_terminator() {
+        let rows = vec![make_row("assistant", "Step one done. Should we proceed?")];
+        let result = extract_next_action(&rows);
+        assert_eq!(result, "Should we proceed?");
+    }
+
+    #[test]
+    fn truncates_long_sentence_at_word_boundary() {
+        let long = format!("First step done. {} action.", "do the next ".repeat(12));
+        let rows = vec![make_row("assistant", &long)];
+        let result = extract_next_action(&rows);
+        assert!(result.ends_with('…'), "expected ellipsis, got: {result}");
+        assert!(
+            result.chars().count() <= MAX_NEXT_ACTION_CHARS + 1,
+            "too long: {} chars",
+            result.chars().count()
+        );
+    }
+
+    #[test]
+    fn unclosed_code_fence_recovers_content() {
+        // Malformed assistant turn: opens a fence but never closes it.
+        // The trailing prose must survive — without the recovery guard
+        // strip_code_fences would silently drop everything after ```rust.
+        let rows = vec![make_row(
+            "assistant",
+            "Here is the plan.\n```rust\nfn main() {}\nNow run cargo build.",
+        )];
+        let result = extract_next_action(&rows);
+        assert!(
+            result.contains("cargo build"),
+            "unclosed-fence content must be recovered, got: {result}"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_sentinel_when_no_assistant() {
+        let rows = vec![make_row("user", "what should I do?")];
+        assert_eq!(extract_next_action(&rows), NO_NEXT_ACTION_SENTINEL);
+    }
+
+    #[test]
+    fn handles_empty_ledger() {
+        assert_eq!(extract_next_action(&[]), NO_NEXT_ACTION_SENTINEL);
+    }
+
+    #[test]
+    fn strips_markdown_bullet_prefix() {
+        let rows = vec![make_row("assistant", "- Run cargo test.")];
+        let result = extract_next_action(&rows);
+        assert_eq!(result, "Run cargo test.");
+    }
+}

--- a/src/distill/open_questions.rs
+++ b/src/distill/open_questions.rs
@@ -1,0 +1,295 @@
+//! `open_questions` extractor — detects unresolved TODOs and open questions.
+//!
+//! No regex crate. Matching is done with `.find()`, `.contains()`, and
+//! sentence splitting via a tiny inline helper. Patterns checked:
+//! - Lines containing `TODO`, `FIXME`, or `XXX` followed by optional `:` and
+//!   text — the rest of the line after the marker is the bullet.
+//! - Sentences (delimited by `. `, `! `, `? `, or end-of-string) that end
+//!   with a `?` character.
+
+use crate::storage::LedgerRow;
+use std::collections::HashSet;
+
+pub const MAX_OPEN_QUESTIONS: usize = 5;
+pub const MAX_BULLET_CHARS: usize = 80;
+
+/// Detect unresolved questions and TODO-style markers across the session.
+/// Returns up to 5 deduplicated bullets.
+///
+/// Rows are walked in chronological order (oldest first). Each row's content
+/// is scanned for TODO/FIXME/XXX markers and sentences ending with `?`.
+/// If the content looks like a JSON array (starts with `[`), it is parsed
+/// and each `text` field extracted before scanning.
+pub fn extract_open_questions(rows: &[LedgerRow]) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut bullets: Vec<String> = Vec::new();
+
+    for row in rows.iter() {
+        let text = resolve_content(&row.content);
+        collect_bullets(&text, &mut seen, &mut bullets);
+        if bullets.len() >= MAX_OPEN_QUESTIONS {
+            break;
+        }
+    }
+
+    bullets.truncate(MAX_OPEN_QUESTIONS);
+    bullets
+}
+
+/// If `content` looks like a JSON array, extract all `"text"` string values
+/// and join them with newlines. Otherwise return the content as-is.
+fn resolve_content(content: &str) -> String {
+    let trimmed = content.trim();
+    if trimmed.starts_with('[') {
+        if let Ok(arr) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            if let Some(items) = arr.as_array() {
+                let texts: Vec<&str> = items
+                    .iter()
+                    .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+                    .collect();
+                if !texts.is_empty() {
+                    return texts.join("\n");
+                }
+            }
+        }
+    }
+    content.to_string()
+}
+
+/// Scan `text` for TODO/FIXME/XXX markers and `?`-terminated sentences;
+/// push new (deduplicated) bullets into `bullets`.
+fn collect_bullets(text: &str, seen: &mut HashSet<String>, bullets: &mut Vec<String>) {
+    if bullets.len() >= MAX_OPEN_QUESTIONS {
+        return;
+    }
+
+    for line in text.lines() {
+        // Check for TODO / FIXME / XXX markers.
+        for marker in &["TODO", "FIXME", "XXX"] {
+            if let Some(capture) = extract_marker_capture(line, marker) {
+                push_bullet(capture, seen, bullets);
+            }
+        }
+
+        // Check for sentences ending with `?`.
+        for sentence in split_sentences(line) {
+            let s = sentence.trim();
+            if s.ends_with('?') && !s.is_empty() {
+                push_bullet(s.to_string(), seen, bullets);
+            }
+        }
+
+        if bullets.len() >= MAX_OPEN_QUESTIONS {
+            return;
+        }
+    }
+}
+
+/// Extract the text after `MARKER` (optionally followed by `:`) on `line`.
+/// Returns `None` if the marker is not present or the capture is empty.
+fn extract_marker_capture(line: &str, marker: &str) -> Option<String> {
+    // Find the marker as a word: it must start at position 0 or after a
+    // non-alphanumeric character, and end before an alphanumeric character.
+    let mut search_from = 0usize;
+    while let Some(pos) = line[search_from..].find(marker) {
+        let abs_pos = search_from + pos;
+        // Check left boundary.
+        let left_ok = abs_pos == 0
+            || !line
+                .as_bytes()
+                .get(abs_pos - 1)
+                .map(|b| b.is_ascii_alphanumeric() || *b == b'_')
+                .unwrap_or(false);
+        // Check right boundary.
+        let after = abs_pos + marker.len();
+        let right_ok = !line
+            .as_bytes()
+            .get(after)
+            .map(|b| b.is_ascii_alphanumeric() || *b == b'_')
+            .unwrap_or(false);
+
+        if left_ok && right_ok {
+            let rest = line[after..].trim_start_matches(':').trim();
+            if !rest.is_empty() {
+                return Some(rest.to_string());
+            }
+            return None;
+        }
+        search_from = abs_pos + 1;
+    }
+    None
+}
+
+/// Split `text` into sentences on `.`, `!`, or `?` followed by whitespace or
+/// end-of-string. The delimiter is kept with the preceding sentence.
+fn split_sentences(text: &str) -> Vec<String> {
+    let mut sentences: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let chars: Vec<char> = text.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        let c = chars[i];
+        current.push(c);
+        if matches!(c, '.' | '!' | '?') {
+            // Peek: next char is whitespace or end-of-string.
+            let next_is_boundary = i + 1 >= len || chars[i + 1].is_whitespace();
+            if next_is_boundary {
+                sentences.push(current.trim().to_string());
+                current = String::new();
+            }
+        }
+        i += 1;
+    }
+    if !current.trim().is_empty() {
+        sentences.push(current.trim().to_string());
+    }
+    sentences
+}
+
+/// Canonicalize `raw` (collapse whitespace) and push into `bullets` if it has
+/// not been seen before. Truncates to `MAX_BULLET_CHARS` at a word boundary.
+fn push_bullet(raw: String, seen: &mut HashSet<String>, bullets: &mut Vec<String>) {
+    if bullets.len() >= MAX_OPEN_QUESTIONS {
+        return;
+    }
+    // Canonicalize: collapse runs of whitespace to single space.
+    let canonical: String = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    if canonical.is_empty() || seen.contains(&canonical) {
+        return;
+    }
+    seen.insert(canonical.clone());
+    bullets.push(truncate_bullet(&canonical));
+}
+
+/// Truncate `s` to at most `MAX_BULLET_CHARS` chars. If truncation is needed,
+/// cut at the last whitespace boundary and append `…`.
+fn truncate_bullet(s: &str) -> String {
+    let char_count = s.chars().count();
+    if char_count <= MAX_BULLET_CHARS {
+        return s.to_string();
+    }
+    let prefix: String = s.chars().take(MAX_BULLET_CHARS).collect();
+    if let Some(boundary) = prefix.rfind(|c: char| c.is_ascii_whitespace()) {
+        let trimmed = prefix[..boundary].trim_end();
+        format!("{}…", trimmed)
+    } else {
+        format!("{}…", prefix)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_row(role: &str, content: &str) -> LedgerRow {
+        LedgerRow {
+            session_id: "s1".to_string(),
+            tool: "claude".to_string(),
+            ts: 0,
+            role: role.to_string(),
+            content: content.to_string(),
+            tool_calls_json: None,
+            files_touched_json: None,
+            parent_id: None,
+        }
+    }
+
+    #[test]
+    fn detects_todo_marker() {
+        let rows = vec![make_row("user", "TODO: fix the bug")];
+        let result = extract_open_questions(&rows);
+        assert!(!result.is_empty(), "expected at least one bullet");
+        assert!(
+            result[0].contains("fix the bug"),
+            "expected capture, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn detects_fixme_marker() {
+        let rows = vec![make_row("assistant", "FIXME: handle the error case")];
+        let result = extract_open_questions(&rows);
+        assert!(!result.is_empty());
+        assert!(result[0].contains("handle the error case"));
+    }
+
+    #[test]
+    fn detects_question_at_end_of_sentence() {
+        let rows = vec![make_row("user", "Should we use Postgres?")];
+        let result = extract_open_questions(&rows);
+        assert!(!result.is_empty(), "expected question bullet");
+        assert!(
+            result.iter().any(|b| b.contains("Should we use Postgres?")),
+            "got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn dedupes_repeated_markers() {
+        let rows = vec![
+            make_row("user", "TODO: same"),
+            make_row("assistant", "TODO: same"),
+            make_row("user", "TODO: same"),
+        ];
+        let result = extract_open_questions(&rows);
+        let count = result.iter().filter(|b| b.contains("same")).count();
+        assert_eq!(
+            count, 1,
+            "expected exactly 1 deduplicated entry, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn caps_at_5_bullets() {
+        let rows: Vec<LedgerRow> = (0..10)
+            .map(|i| make_row("user", &format!("TODO: unique item {i}")))
+            .collect();
+        let result = extract_open_questions(&rows);
+        assert_eq!(result.len(), MAX_OPEN_QUESTIONS);
+    }
+
+    #[test]
+    fn truncates_long_bullets() {
+        let long_todo = format!("TODO: {}", "word ".repeat(30));
+        let rows = vec![make_row("user", &long_todo)];
+        let result = extract_open_questions(&rows);
+        assert!(!result.is_empty());
+        assert!(
+            result[0].ends_with('…'),
+            "expected ellipsis on long bullet, got: {}",
+            result[0]
+        );
+        assert!(
+            result[0].chars().count() <= MAX_BULLET_CHARS + 1,
+            "bullet too long: {} chars",
+            result[0].chars().count()
+        );
+    }
+
+    #[test]
+    fn handles_empty_ledger() {
+        let result = extract_open_questions(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn handles_array_content() {
+        let content = r#"[{"type":"text","text":"TODO: x"}]"#;
+        let rows = vec![make_row("user", content)];
+        let result = extract_open_questions(&rows);
+        assert!(
+            !result.is_empty(),
+            "expected bullet from JSON array content"
+        );
+        assert!(result[0].contains('x'), "got: {:?}", result);
+    }
+}

--- a/src/distill/task.rs
+++ b/src/distill/task.rs
@@ -1,0 +1,137 @@
+//! `task` extractor — condenses the latest substantial user turn into one line.
+
+use crate::storage::LedgerRow;
+
+pub const MAX_TASK_CHARS: usize = 120;
+pub const NO_TASK_SENTINEL: &str = "<no task captured>";
+
+/// Extract a one-line summary of the user's current task from the latest
+/// substantial user turn in the ledger.
+///
+/// Algorithm:
+/// 1. Iterate rows in reverse (newest first).
+/// 2. Find the most recent row with `role == "user"` whose `content.trim()` is
+///    non-empty.
+/// 3. Take only the first non-empty line of that content.
+/// 4. If the line exceeds `MAX_TASK_CHARS`, truncate at the last word boundary
+///    before the cap and append `…`.
+/// 5. Return the result, or `NO_TASK_SENTINEL` when no qualifying row exists.
+pub fn extract_task(rows: &[LedgerRow]) -> String {
+    for row in rows.iter().rev() {
+        if row.role != "user" {
+            continue;
+        }
+        let trimmed = row.content.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Take the first non-empty line.
+        let first_line = trimmed
+            .lines()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .unwrap_or(trimmed);
+
+        return truncate_at_word(first_line, MAX_TASK_CHARS);
+    }
+    NO_TASK_SENTINEL.to_string()
+}
+
+/// Truncate `s` to at most `max_chars` characters (by char count). If truncation
+/// is needed, cut at the last ASCII word boundary before the limit and append `…`.
+fn truncate_at_word(s: &str, max_chars: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        return s.to_string();
+    }
+    // Collect up to max_chars chars.
+    let prefix: String = s.chars().take(max_chars).collect();
+    // Find last whitespace boundary in the prefix.
+    if let Some(boundary) = prefix.rfind(|c: char| c.is_ascii_whitespace()) {
+        let trimmed = prefix[..boundary].trim_end();
+        format!("{}…", trimmed)
+    } else {
+        // No word boundary — hard-cut.
+        format!("{}…", prefix)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_row(role: &str, content: &str) -> LedgerRow {
+        LedgerRow {
+            session_id: "s1".to_string(),
+            tool: "claude".to_string(),
+            ts: 0,
+            role: role.to_string(),
+            content: content.to_string(),
+            tool_calls_json: None,
+            files_touched_json: None,
+            parent_id: None,
+        }
+    }
+
+    #[test]
+    fn extracts_latest_user_prompt() {
+        let rows = vec![
+            make_row("user", "first user message"),
+            make_row("assistant", "some response"),
+            make_row("user", "second user message"),
+        ];
+        assert_eq!(extract_task(&rows), "second user message");
+    }
+
+    #[test]
+    fn truncates_long_prompt_at_word_boundary() {
+        // Build a string with 130 chars that has a clear word boundary before 120.
+        let long = format!("{} {}", "a".repeat(115), "b".repeat(14));
+        let rows = vec![make_row("user", &long)];
+        let result = extract_task(&rows);
+        // Result should end with ellipsis.
+        assert!(result.ends_with('…'), "expected ellipsis, got: {result}");
+        // Char length: ≤ 121 (120 chars + 1 for '…', which is 3 UTF-8 bytes but 1 char).
+        assert!(
+            result.chars().count() <= 121,
+            "result too long: {} chars",
+            result.chars().count()
+        );
+    }
+
+    #[test]
+    fn condenses_multiline_to_first_line() {
+        let content = "first line\nsecond line\nthird line";
+        let rows = vec![make_row("user", content)];
+        assert_eq!(extract_task(&rows), "first line");
+    }
+
+    #[test]
+    fn handles_empty_ledger() {
+        assert_eq!(extract_task(&[]), NO_TASK_SENTINEL);
+    }
+
+    #[test]
+    fn handles_no_user_rows() {
+        let rows = vec![
+            make_row("assistant", "response"),
+            make_row("system", "system msg"),
+        ];
+        assert_eq!(extract_task(&rows), NO_TASK_SENTINEL);
+    }
+
+    #[test]
+    fn skips_empty_user_content() {
+        let rows = vec![
+            make_row("user", "earlier good message"),
+            make_row("user", ""),
+            make_row("user", "   "),
+        ];
+        // Both latter rows are whitespace-only; should fall back to the earliest good one.
+        assert_eq!(extract_task(&rows), "earlier good message");
+    }
+}


### PR DESCRIPTION
Pure-code transforms over `LedgerRow` batches. Each extractor produces one component a future publisher will splice into the 50-line handoff template.

What this introduces:
- `task`: condenses the latest substantial user prompt to one line, capped at 120 chars with word-boundary truncation. Sentinel when no user content captured.
- `open_questions`: detects `TODO` / `FIXME` / `XXX` markers and `?`-terminated sentences across the session. HashSet-deduplicated, capped at 5 bullets. Custom word-boundary matcher — no `regex` crate added.
- `next_action`: extracts the final actionable sentence of the latest assistant turn. Strips Markdown code fences (recovers content when a fence is opened but never closed) and bullet/ordered-list prefixes before sentence splitting.

All three are pure functions: `(rows: &[LedgerRow]) -> String | Vec<String>`. No I/O, no errors, no panics on empty input.

Test plan:
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (77 passed: 74 unit + 3 integration, 1 ignored)
- [x] cargo-deny check (advisories + bans + licenses + sources all ok)
- [x] No regex crate (Cargo.toml unchanged)
- [x] Unclosed-code-fence recovery test guards against silent content loss