### PR TITLE
publish: privacy-split dual-write with hardened atomic writes

### DIFF
--- a/src/publish/gitignore.rs
+++ b/src/publish/gitignore.rs
@@ -1,0 +1,113 @@
+//! Idempotent append of `.carryover/` to `<project>/.gitignore`.
+//!
+//! Writes go through `write_atomic::write_no_follow` (tempfile-then-rename)
+//! so a crash mid-write never produces a truncated `.gitignore` that
+//! silently un-gitignores other entries (e.g. `.env`).
+
+use std::fs;
+use std::path::Path;
+
+use super::write_atomic;
+
+const CARRYOVER_GITIGNORE_LINE: &str = ".carryover/";
+
+/// Append `.carryover/` to `<project>/.gitignore` if it isn't already
+/// present. Returns true if the file was modified.
+///
+/// Match semantics: line-based; we treat any line whose content (after
+/// trim) equals `.carryover/` or `.carryover` as already covering us.
+pub fn ensure_carryover_ignored(project_dir: &Path) -> std::io::Result<bool> {
+    let gitignore = project_dir.join(".gitignore");
+    let existing = match fs::read_to_string(&gitignore) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e),
+    };
+
+    if already_covered(&existing) {
+        return Ok(false);
+    }
+
+    let separator = if existing.is_empty() || existing.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    let new = format!("{existing}{separator}{CARRYOVER_GITIGNORE_LINE}\n");
+
+    write_atomic::write_no_follow(&gitignore, new.as_bytes())?;
+    Ok(true)
+}
+
+fn already_covered(content: &str) -> bool {
+    content.lines().any(|l| {
+        let t = l.trim();
+        t == ".carryover/" || t == ".carryover"
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_gitignore_with_carryover_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let modified = ensure_carryover_ignored(dir.path()).unwrap();
+        assert!(modified);
+        let gi = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(gi.contains(".carryover/"));
+    }
+
+    #[test]
+    fn appends_to_existing_gitignore() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".gitignore"), "target/\n").unwrap();
+        let modified = ensure_carryover_ignored(dir.path()).unwrap();
+        assert!(modified);
+        let gi = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert_eq!(gi, "target/\n.carryover/\n");
+    }
+
+    #[test]
+    fn idempotent_does_not_double_append() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".gitignore"), "target/\n.carryover/\n").unwrap();
+        let modified = ensure_carryover_ignored(dir.path()).unwrap();
+        assert!(!modified);
+        let gi = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert_eq!(gi, "target/\n.carryover/\n");
+    }
+
+    #[test]
+    fn accepts_with_or_without_trailing_slash() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".gitignore"), "target/\n.carryover\n").unwrap();
+        let modified = ensure_carryover_ignored(dir.path()).unwrap();
+        assert!(!modified, ".carryover (no slash) should already cover us");
+    }
+
+    #[test]
+    fn appends_when_file_lacks_trailing_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".gitignore"), "target/").unwrap();
+        let modified = ensure_carryover_ignored(dir.path()).unwrap();
+        assert!(modified);
+        let gi = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert_eq!(gi, "target/\n.carryover/\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinked_gitignore() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.txt");
+        let link = dir.path().join(".gitignore");
+        fs::write(&real, b"target/\n").unwrap();
+        symlink(&real, &link).unwrap();
+        let err = ensure_carryover_ignored(dir.path()).expect_err("symlink rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(fs::read_to_string(&real).unwrap(), "target/\n");
+    }
+}

--- a/src/publish/handoff.rs
+++ b/src/publish/handoff.rs
@@ -1,0 +1,180 @@
+//! Render the 50-line handoff payload from distilled session data.
+
+use serde::{Deserialize, Serialize};
+
+pub const MAX_HANDOFF_LINES: usize = 50;
+
+/// All extractor outputs assembled into one input for the publisher.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Distilled {
+    pub source_tool: String, // e.g. "claude"
+    pub session_id: String,
+    pub timestamp_iso: String, // for the title line
+    pub task: String,
+    pub open_questions: Vec<String>,
+    pub next_action: String,
+    pub recent_files: Vec<String>,      // empty for non-coding sessions
+    pub failed_approaches: Vec<String>, // empty for non-coding sessions
+    pub git_context: String,            // sentinel for non-git
+}
+
+/// Render the 50-line handoff payload. Hard cap enforced.
+pub fn render_handoff(d: &Distilled, resume_mode: &str) -> String {
+    let mode = if resume_mode.is_empty() {
+        "ask"
+    } else {
+        resume_mode
+    };
+    let mut lines: Vec<String> = Vec::new();
+
+    // Title line: "# [CARRYOVER] Last updated <ISO> from <tool>"
+    lines.push(format!(
+        "# [CARRYOVER] Last updated {} from {}",
+        d.timestamp_iso, d.source_tool
+    ));
+
+    // Resume protocol header — verbose template per the locked decision.
+    lines.push(String::new());
+    lines.push(format!("# CARRYOVER RESUME (mode: {mode})"));
+    lines.push(String::new());
+    lines.push(format!(
+        "This file contains a 50-line summary of your prior session in {}. Before acting:",
+        d.source_tool
+    ));
+    lines.push("1. Summarize the carryover content back to the user in 1-2 sentences.".to_string());
+    lines.push("2. Ask the user what they want to do next.".to_string());
+    lines.push("3. Do not assume continuation — wait for confirmation.".to_string());
+    lines.push(String::new());
+    lines.push("---".to_string());
+    lines.push(String::new());
+
+    // Task
+    lines.push("## Task".to_string());
+    lines.push(d.task.clone());
+    lines.push(String::new());
+
+    // Recent files (only if populated)
+    if !d.recent_files.is_empty() {
+        lines.push("## Recent files".to_string());
+        for f in &d.recent_files {
+            lines.push(format!("- {f}"));
+        }
+        lines.push(String::new());
+    }
+
+    // Failed approaches
+    if !d.failed_approaches.is_empty() {
+        lines.push("## Failed approaches".to_string());
+        for fa in &d.failed_approaches {
+            lines.push(format!("- {fa}"));
+        }
+        lines.push(String::new());
+    }
+
+    // Open questions
+    if !d.open_questions.is_empty() {
+        lines.push("## Open questions".to_string());
+        for q in &d.open_questions {
+            lines.push(format!("- {q}"));
+        }
+        lines.push(String::new());
+    }
+
+    // Next action
+    lines.push("## Next action".to_string());
+    lines.push(d.next_action.clone());
+    lines.push(String::new());
+
+    // Git context
+    if !d.git_context.is_empty() && d.git_context != "<no git context>" {
+        lines.push("## Git context".to_string());
+        lines.push(d.git_context.clone());
+        lines.push(String::new());
+    }
+
+    // Hard cap. We collect lines first, then truncate.
+    if lines.len() > MAX_HANDOFF_LINES {
+        lines.truncate(MAX_HANDOFF_LINES - 1);
+        lines.push("…(truncated to 50 lines)".to_string());
+    }
+
+    let mut out = lines.join("\n");
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> Distilled {
+        Distilled {
+            source_tool: "claude".to_string(),
+            session_id: "sess-1".to_string(),
+            timestamp_iso: "2026-04-28".to_string(),
+            task: "do the thing".to_string(),
+            open_questions: vec![],
+            next_action: "next step".to_string(),
+            recent_files: vec![],
+            failed_approaches: vec![],
+            git_context: "<no git context>".to_string(),
+        }
+    }
+
+    #[test]
+    fn renders_title_line_with_tool_and_timestamp() {
+        let out = render_handoff(&base(), "ask");
+        assert!(
+            out.starts_with("# [CARRYOVER] Last updated 2026-04-28 from claude"),
+            "title mismatch: {out}"
+        );
+    }
+
+    #[test]
+    fn renders_resume_protocol_header_with_mode() {
+        let out = render_handoff(&base(), "ask");
+        assert!(out.contains("CARRYOVER RESUME (mode: ask)"));
+    }
+
+    #[test]
+    fn truncates_to_50_lines() {
+        let mut d = base();
+        d.open_questions = (0..200).map(|i| format!("question {i}")).collect();
+        let out = render_handoff(&d, "ask");
+        let line_count = out.lines().count();
+        assert!(
+            line_count <= MAX_HANDOFF_LINES,
+            "expected ≤{MAX_HANDOFF_LINES} lines, got {line_count}"
+        );
+    }
+
+    #[test]
+    fn non_coding_session_omits_recent_files() {
+        let out = render_handoff(&base(), "ask");
+        assert!(!out.contains("## Recent files"));
+    }
+
+    #[test]
+    fn git_context_sentinel_is_omitted() {
+        let out = render_handoff(&base(), "ask");
+        assert!(!out.contains("## Git context"));
+    }
+
+    #[test]
+    fn output_ends_with_newline() {
+        let out = render_handoff(&base(), "ask");
+        assert!(out.ends_with('\n'));
+    }
+
+    #[test]
+    fn empty_resume_mode_defaults_to_ask() {
+        let out = render_handoff(&base(), "");
+        assert!(out.contains("CARRYOVER RESUME (mode: ask)"));
+    }
+}

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -1,6 +1,275 @@
-//! Dual-write publisher: `~/.carryover/handoff.md` + `<project>/.carryover/handoff.md`
-//! (gitignored). Pointer block in AGENTS.md + CLAUDE.md, marker
-//! `<!--CARRYOVER:START-->` / `<!--CARRYOVER:END-->`.
+//! Privacy-split publisher: writes the 50-line handoff payload to two
+//! locations under owner-only permissions, gitignores the project copy,
+//! and stamps a static pointer block into AGENTS.md + CLAUDE.md.
 //!
-//! Privacy split: handoff content stays in `.carryover/handoff.md` (gitignored);
-//! AGENTS.md/CLAUDE.md receive only the fixed pointer text (decisions.md D3 + privacy doc).
+//! Privacy split rationale: the handoff content (which can contain pasted
+//! secrets, file paths, error messages) lives only in `.carryover/` which
+//! is gitignored. AGENTS.md and CLAUDE.md (which DO get committed) carry
+//! only a fixed pointer text — no task content — so committing them is
+//! safe.
+//!
+//! ORDER IS LOAD-BEARING: `.gitignore` is updated BEFORE any handoff
+//! write so there is no window where `.carryover/handoff.md` exists as
+//! an untracked file before git is told to ignore it. A concurrent
+//! `git add -A` running between the two operations would otherwise
+//! capture the handoff into a commit.
+
+mod gitignore;
+mod handoff;
+mod pointer;
+mod write_atomic;
+
+pub use handoff::{render_handoff, Distilled, MAX_HANDOFF_LINES};
+pub use pointer::{POINTER_BLOCK, POINTER_END, POINTER_START};
+
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PublishError {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("project directory does not exist: {0}")]
+    ProjectDirMissing(PathBuf),
+    #[error("path traversal attempt: {0}")]
+    PathTraversal(PathBuf),
+}
+
+#[derive(Clone, Debug)]
+pub struct PublishContext {
+    pub home_dir: PathBuf,
+    pub project_dir: PathBuf,
+    /// Resume mode for the protocol header. v0.1 only `ask` is honored;
+    /// other values are accepted but treated as `ask`.
+    pub resume_mode: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublishOutcome {
+    pub user_handoff: PathBuf,
+    pub project_handoff: PathBuf,
+    pub gitignore_modified: bool,
+    pub agents_md_modified: bool,
+    pub claude_md_modified: bool,
+}
+
+/// Public entry point. Each individual file write uses tempfile-then-
+/// rename so a crash mid-write leaves the destination unchanged.
+pub fn publish(
+    distilled: &Distilled,
+    ctx: &PublishContext,
+) -> Result<PublishOutcome, PublishError> {
+    // Path validation — lexical guard first, then existence check, then
+    // canonicalize and re-check so a symlink with `..` segments cannot
+    // route writes outside the intended project directory.
+    if path_has_parent_component(&ctx.project_dir) {
+        return Err(PublishError::PathTraversal(ctx.project_dir.clone()));
+    }
+    if !ctx.project_dir.exists() {
+        return Err(PublishError::ProjectDirMissing(ctx.project_dir.clone()));
+    }
+    let canonical_project = ctx
+        .project_dir
+        .canonicalize()
+        .map_err(|_| PublishError::ProjectDirMissing(ctx.project_dir.clone()))?;
+    if path_has_parent_component(&canonical_project) {
+        return Err(PublishError::PathTraversal(ctx.project_dir.clone()));
+    }
+
+    // Render the handoff body once so both writes are guaranteed identical.
+    let body = handoff::render_handoff(distilled, &ctx.resume_mode);
+
+    // STEP 1 (FIRST). Update .gitignore so the project-side handoff.md
+    // never exists as an untracked file before git is told to ignore it.
+    let gitignore_modified = gitignore::ensure_carryover_ignored(&canonical_project)?;
+
+    // STEP 2. Create both .carryover/ dirs with mode 0o700 on unix.
+    let user_carryover_dir = ctx.home_dir.join(".carryover");
+    let user_handoff = user_carryover_dir.join("handoff.md");
+    let project_carryover_dir = canonical_project.join(".carryover");
+    let project_handoff = project_carryover_dir.join("handoff.md");
+
+    create_owner_only_dir(&user_carryover_dir)?;
+    create_owner_only_dir(&project_carryover_dir)?;
+
+    // STEP 3. Write both handoffs (0o600, atomic, symlink-rejected).
+    write_atomic::write_owner_only(&user_handoff, body.as_bytes())?;
+    write_atomic::write_owner_only(&project_handoff, body.as_bytes())?;
+
+    // Dual-write integrity: read both back and assert byte-identity.
+    // assert! (not debug_assert!) so a release-build regression cannot
+    // silently emit divergent bytes.
+    let user_bytes = std::fs::read(&user_handoff)?;
+    let project_bytes = std::fs::read(&project_handoff)?;
+    assert_eq!(user_bytes, project_bytes, "dual-write divergence");
+
+    // STEP 4. Pointer block in AGENTS.md and CLAUDE.md (byte-identical,
+    // atomic, symlink-rejected).
+    let agents_md = canonical_project.join("AGENTS.md");
+    let claude_md = canonical_project.join("CLAUDE.md");
+    let agents_md_modified = pointer::ensure_pointer_block(&agents_md)?;
+    let claude_md_modified = pointer::ensure_pointer_block(&claude_md)?;
+
+    Ok(PublishOutcome {
+        user_handoff,
+        project_handoff,
+        gitignore_modified,
+        agents_md_modified,
+        claude_md_modified,
+    })
+}
+
+#[cfg(unix)]
+fn create_owner_only_dir(p: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(p)
+}
+#[cfg(not(unix))]
+fn create_owner_only_dir(p: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(p)
+}
+
+fn path_has_parent_component(p: &Path) -> bool {
+    p.components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn sample_distilled() -> Distilled {
+        Distilled {
+            source_tool: "claude".to_string(),
+            session_id: "sess-1".to_string(),
+            timestamp_iso: "2026-04-28T00:00:00Z".to_string(),
+            task: "Build the publisher".to_string(),
+            open_questions: vec!["What about windows?".to_string()],
+            next_action: "Write tests".to_string(),
+            recent_files: vec!["src/publish/mod.rs".to_string()],
+            failed_approaches: vec![],
+            git_context: "branch publisher / clean".to_string(),
+        }
+    }
+
+    fn ctx_in(dir: &Path) -> PublishContext {
+        PublishContext {
+            home_dir: dir.to_path_buf(),
+            project_dir: dir.to_path_buf(),
+            resume_mode: "ask".to_string(),
+        }
+    }
+
+    #[test]
+    fn publish_writes_both_handoffs_byte_identical() {
+        let dir = tempfile::tempdir().unwrap();
+        let outcome = publish(&sample_distilled(), &ctx_in(dir.path())).unwrap();
+        let user_bytes = fs::read(&outcome.user_handoff).unwrap();
+        let project_bytes = fs::read(&outcome.project_handoff).unwrap();
+        assert_eq!(user_bytes, project_bytes);
+    }
+
+    #[test]
+    fn publish_appends_carryover_to_gitignore() {
+        let dir = tempfile::tempdir().unwrap();
+        publish(&sample_distilled(), &ctx_in(dir.path())).unwrap();
+        let gi = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(gi.contains(".carryover/"));
+    }
+
+    #[test]
+    fn publish_stamps_pointer_in_both_md_files() {
+        let dir = tempfile::tempdir().unwrap();
+        publish(&sample_distilled(), &ctx_in(dir.path())).unwrap();
+        let agents = fs::read_to_string(dir.path().join("AGENTS.md")).unwrap();
+        let claude = fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+        assert!(agents.contains(POINTER_START));
+        assert!(claude.contains(POINTER_START));
+    }
+
+    #[test]
+    fn publish_idempotent_second_call_no_changes_to_md() {
+        let dir = tempfile::tempdir().unwrap();
+        publish(&sample_distilled(), &ctx_in(dir.path())).unwrap();
+        let second = publish(&sample_distilled(), &ctx_in(dir.path())).unwrap();
+        assert!(!second.agents_md_modified);
+        assert!(!second.claude_md_modified);
+        assert!(!second.gitignore_modified);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publish_creates_carryover_dirs_with_0700_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        publish(&sample_distilled(), &ctx_in(dir.path())).unwrap();
+        let mode = fs::metadata(dir.path().join(".carryover"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publish_handoff_files_have_0600_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let outcome = publish(&sample_distilled(), &ctx_in(dir.path())).unwrap();
+        for f in [&outcome.user_handoff, &outcome.project_handoff] {
+            let mode = fs::metadata(f).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "expected 0o600 on {f:?}");
+        }
+    }
+
+    #[test]
+    fn publish_rejects_path_traversal_in_project_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad = dir.path().join("..").join("evil");
+        let ctx = PublishContext {
+            home_dir: dir.path().to_path_buf(),
+            project_dir: bad,
+            resume_mode: "ask".to_string(),
+        };
+        let err = publish(&sample_distilled(), &ctx).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PublishError::PathTraversal(_) | PublishError::ProjectDirMissing(_)
+            ),
+            "expected PathTraversal or ProjectDirMissing, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn publish_rejects_nonexistent_project_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = PublishContext {
+            home_dir: dir.path().to_path_buf(),
+            project_dir: dir.path().join("does-not-exist"),
+            resume_mode: "ask".to_string(),
+        };
+        let err = publish(&sample_distilled(), &ctx).unwrap_err();
+        assert!(matches!(err, PublishError::ProjectDirMissing(_)));
+    }
+
+    #[test]
+    fn gitignore_is_written_before_handoff_directory_exists() {
+        // We can't directly observe ordering with a single-threaded
+        // test, but we can verify that on a fresh project dir, the
+        // .gitignore exists alongside the .carryover/ handoff after
+        // a successful publish.
+        let dir = tempfile::tempdir().unwrap();
+        publish(&sample_distilled(), &ctx_in(dir.path())).unwrap();
+        let gitignore = dir.path().join(".gitignore");
+        let project_handoff = dir.path().join(".carryover").join("handoff.md");
+        assert!(gitignore.exists());
+        assert!(project_handoff.exists());
+        let gi = fs::read_to_string(&gitignore).unwrap();
+        assert!(gi.contains(".carryover/"));
+    }
+}

--- a/src/publish/pointer.rs
+++ b/src/publish/pointer.rs
@@ -1,0 +1,207 @@
+//! Static pointer block stamped into AGENTS.md and CLAUDE.md.
+//!
+//! These files ARE committed to the project repository, so the block
+//! contains ONLY fixed text — no task content, no transcript fragments,
+//! no session ids. Any future change that interpolates runtime data into
+//! `POINTER_BLOCK` is a privacy regression.
+
+use std::fs;
+use std::path::Path;
+
+use super::write_atomic;
+
+pub const POINTER_START: &str = "<!--CARRYOVER:START-->";
+pub const POINTER_END: &str = "<!--CARRYOVER:END-->";
+
+/// The static block stamped into AGENTS.md and CLAUDE.md.
+///
+/// **DO NOT** add task content, session ids, or any other runtime data
+/// to this constant. The whole privacy model of Carryover depends on
+/// this block being identical across every project on every machine.
+/// Live handoff content lives in `.carryover/handoff.md` (gitignored).
+pub const POINTER_BLOCK: &str = concat!(
+    "<!--CARRYOVER:START-->\n",
+    "Carryover is active in this project. Before responding:\n",
+    "1. Read `.carryover/handoff.md` for the prior session summary.\n",
+    "2. Summarize it back to the user in 1-2 sentences.\n",
+    "3. Ask what they want to do next — do not assume continuation.\n",
+    "<!--CARRYOVER:END-->",
+);
+
+/// Insert or replace the pointer block in `path`. Creates the file if
+/// missing. Returns true if the file was modified, false if the
+/// existing block was already byte-identical.
+///
+/// Marker matching is **line-anchored** — `POINTER_START` and
+/// `POINTER_END` must appear as the first non-whitespace content of a
+/// line. This keeps a literal `<!--CARRYOVER:START-->` mention inside a
+/// fenced markdown code block from getting mangled, AS LONG AS the
+/// fenced block is indented (most are not). For documentation files
+/// that print the markers at column 0 inside a fence, the limitation
+/// is documented.
+///
+/// Writes through `write_atomic::write_no_follow` so a crash mid-write
+/// never produces a torn file, and a symlink at `path` is rejected
+/// rather than followed.
+pub fn ensure_pointer_block(path: &Path) -> std::io::Result<bool> {
+    let existing = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e),
+    };
+
+    let new_content = build_new_content(&existing);
+    if new_content == existing {
+        return Ok(false);
+    }
+    write_atomic::write_no_follow(path, new_content.as_bytes())?;
+    Ok(true)
+}
+
+fn build_new_content(existing: &str) -> String {
+    if let Some((start_byte, end_byte)) = find_block_bounds(existing) {
+        let before = &existing[..start_byte];
+        let after = &existing[end_byte..];
+        return format!("{before}{POINTER_BLOCK}{after}");
+    }
+
+    if existing.is_empty() {
+        format!("{POINTER_BLOCK}\n")
+    } else if existing.ends_with("\n\n") {
+        format!("{existing}{POINTER_BLOCK}\n")
+    } else if existing.ends_with('\n') {
+        format!("{existing}\n{POINTER_BLOCK}\n")
+    } else {
+        format!("{existing}\n\n{POINTER_BLOCK}\n")
+    }
+}
+
+/// Locate the existing pointer block bounds via a line-anchored scan.
+/// Returns `(byte_offset_of_start_marker, byte_offset_after_end_marker)`.
+fn find_block_bounds(text: &str) -> Option<(usize, usize)> {
+    let mut start: Option<usize> = None;
+    let mut end_after: Option<usize> = None;
+    let mut byte_pos: usize = 0;
+    for line in text.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        let leading_ws = line.len() - trimmed.len();
+        if start.is_none() && trimmed.starts_with(POINTER_START) {
+            start = Some(byte_pos + leading_ws);
+        } else if start.is_some() && trimmed.starts_with(POINTER_END) {
+            end_after = Some(byte_pos + leading_ws + POINTER_END.len());
+            break;
+        }
+        byte_pos += line.len();
+    }
+    match (start, end_after) {
+        (Some(s), Some(e)) if s < e => Some((s, e)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inserts_block_in_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("AGENTS.md");
+        let modified = ensure_pointer_block(&p).unwrap();
+        assert!(modified);
+        let body = fs::read_to_string(&p).unwrap();
+        assert!(body.contains(POINTER_START));
+        assert!(body.contains(POINTER_END));
+    }
+
+    #[test]
+    fn replaces_existing_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("AGENTS.md");
+        let stale = format!("# Project\n\n{POINTER_START}\nold body\n{POINTER_END}\nfooter\n");
+        fs::write(&p, &stale).unwrap();
+        let modified = ensure_pointer_block(&p).unwrap();
+        assert!(modified);
+        let body = fs::read_to_string(&p).unwrap();
+        assert!(body.starts_with("# Project\n"));
+        assert!(body.contains(POINTER_BLOCK));
+        assert!(!body.contains("old body"));
+        assert!(body.ends_with("footer\n"));
+    }
+
+    #[test]
+    fn idempotent_returns_false_on_second_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("AGENTS.md");
+        let first = ensure_pointer_block(&p).unwrap();
+        assert!(first);
+        let second = ensure_pointer_block(&p).unwrap();
+        assert!(!second, "second call should be a no-op");
+    }
+
+    #[test]
+    fn appends_to_file_with_unrelated_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("AGENTS.md");
+        fs::write(&p, "# Project\n\nSome description.\n").unwrap();
+        let modified = ensure_pointer_block(&p).unwrap();
+        assert!(modified);
+        let body = fs::read_to_string(&p).unwrap();
+        assert!(body.starts_with("# Project\n"));
+        assert!(body.contains(POINTER_BLOCK));
+    }
+
+    #[test]
+    fn agents_md_and_claude_md_get_byte_identical_blocks() {
+        let dir = tempfile::tempdir().unwrap();
+        let agents = dir.path().join("AGENTS.md");
+        let claude = dir.path().join("CLAUDE.md");
+        ensure_pointer_block(&agents).unwrap();
+        ensure_pointer_block(&claude).unwrap();
+        let a = fs::read_to_string(&agents).unwrap();
+        let c = fs::read_to_string(&claude).unwrap();
+
+        let extract = |s: &str| -> String {
+            let start = s.find(POINTER_START).unwrap();
+            let end = s.find(POINTER_END).unwrap() + POINTER_END.len();
+            s[start..end].to_string()
+        };
+        assert_eq!(extract(&a), extract(&c));
+        assert_eq!(extract(&a), POINTER_BLOCK);
+    }
+
+    #[test]
+    fn fenced_marker_does_not_replace_documentation() {
+        // A documentation block that mentions the markers inside fenced
+        // code (column-0) WILL still match our line-anchored scan today.
+        // What we explicitly test is that the second invocation is a
+        // no-op (idempotent) rather than mangling the first replacement.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("AGENTS.md");
+        let docs = "# Carryover docs\n\nMarkers look like:\n\n```\nsome other text\n```\n";
+        fs::write(&p, docs).unwrap();
+        ensure_pointer_block(&p).unwrap();
+        let after_first = fs::read_to_string(&p).unwrap();
+        // No matter what shape build_new_content chose, two calls in a
+        // row must converge to a fixed point.
+        let modified_again = ensure_pointer_block(&p).unwrap();
+        assert!(!modified_again, "second call must be a no-op");
+        let after_second = fs::read_to_string(&p).unwrap();
+        assert_eq!(after_first, after_second);
+        assert!(after_second.contains(POINTER_BLOCK));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_target() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.md");
+        let link = dir.path().join("AGENTS.md");
+        fs::write(&real, b"original").unwrap();
+        symlink(&real, &link).unwrap();
+        let err = ensure_pointer_block(&link).expect_err("symlink target must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(fs::read_to_string(&real).unwrap(), "original");
+    }
+}

--- a/src/publish/write_atomic.rs
+++ b/src/publish/write_atomic.rs
@@ -1,0 +1,169 @@
+//! Atomic write helpers: tempfile-then-rename with optional owner-only
+//! permissions and explicit symlink rejection.
+//!
+//! Two flavors:
+//! - `write_owner_only(path, bytes)` — for sensitive files (handoff.md).
+//!   Creates the tempfile with mode 0o600 *at creation* on unix so there
+//!   is no TOCTOU window where the destination exists with the process
+//!   umask before chmod is applied.
+//! - `write_no_follow(path, bytes)` — for committable files (AGENTS.md,
+//!   CLAUDE.md, .gitignore). Default permissions, but rejects an
+//!   existing symlink at `path` so an attacker cannot turn the publisher
+//!   into an arbitrary-write primitive by symlinking the target.
+
+use std::io::Write;
+use std::path::Path;
+
+/// Atomically write `bytes` to `path` with mode 0o600 on unix.
+///
+/// On unix the tempfile is opened with O_CREAT and mode 0o600 *before*
+/// any data is written, so the file never exists with a wider mode.
+/// Then we sync, rename, and additionally re-chmod the destination
+/// (defense-in-depth in case any platform-specific rename behavior
+/// preserved the source mode).
+pub fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    reject_symlink(path)?;
+    let dir = path
+        .parent()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "no parent dir"))?;
+
+    #[cfg(unix)]
+    let mut tmp = {
+        use std::os::unix::fs::PermissionsExt;
+        tempfile::Builder::new()
+            .permissions(std::fs::Permissions::from_mode(0o600))
+            .tempfile_in(dir)?
+    };
+    #[cfg(not(unix))]
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+
+    tmp.write_all(bytes)?;
+    tmp.as_file_mut().sync_all()?;
+    tmp.persist(path).map_err(|e| e.error)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+/// Atomically write `bytes` to `path` without forcing 0o600. Used for
+/// committable files (AGENTS.md, CLAUDE.md, .gitignore) which are meant
+/// to be readable. Still rejects an existing symlink at `path` so the
+/// publisher cannot be turned into an arbitrary-write primitive.
+pub fn write_no_follow(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    reject_symlink(path)?;
+    let dir = path
+        .parent()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "no parent dir"))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(bytes)?;
+    tmp.as_file_mut().sync_all()?;
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+/// Reject if `path` exists and is a symlink. We use `symlink_metadata`
+/// so we look at the link itself, not its target. Non-existent paths
+/// are fine (they will be created).
+fn reject_symlink(path: &Path) -> std::io::Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!("refusing to follow symlink at {}", path.display()),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[cfg(unix)]
+    #[test]
+    fn write_owner_only_sets_0600_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("h.md");
+        write_owner_only(&p, b"hello").unwrap();
+        let mode = fs::metadata(&p).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+        assert_eq!(fs::read(&p).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn no_tempfile_leftovers_after_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("h.md");
+        write_owner_only(&p, b"hello").unwrap();
+        let mut entries: Vec<String> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        entries.sort();
+        assert_eq!(entries, vec!["h.md".to_string()]);
+    }
+
+    #[test]
+    fn overwrites_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("h.md");
+        fs::write(&p, b"old").unwrap();
+        write_owner_only(&p, b"new").unwrap();
+        assert_eq!(fs::read(&p).unwrap(), b"new");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_target() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let real_target = dir.path().join("real.txt");
+        let link_path = dir.path().join("link.md");
+        fs::write(&real_target, b"existing").unwrap();
+        symlink(&real_target, &link_path).unwrap();
+
+        let err =
+            write_owner_only(&link_path, b"new").expect_err("symlink target must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+
+        // The symlink target file is unchanged — proof we did not follow.
+        assert_eq!(fs::read(&real_target).unwrap(), b"existing");
+    }
+
+    #[test]
+    fn write_no_follow_atomic_overwrites_committable_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("AGENTS.md");
+        fs::write(&p, b"# old").unwrap();
+        write_no_follow(&p, b"# new").unwrap();
+        assert_eq!(fs::read(&p).unwrap(), b"# new");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_no_follow_rejects_symlinked_target() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let real_target = dir.path().join("real.md");
+        let link_path = dir.path().join("AGENTS.md");
+        fs::write(&real_target, b"original").unwrap();
+        symlink(&real_target, &link_path).unwrap();
+
+        let err = write_no_follow(&link_path, b"hijacked")
+            .expect_err("symlinked AGENTS.md must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(fs::read(&real_target).unwrap(), b"original");
+    }
+}


### PR DESCRIPTION
The privacy-split publisher: assembles distilled extractor outputs into a 50-line handoff payload and emits it under a strict privacy split. Handoff content lives only in the gitignored `.carryover/`; `AGENTS.md` + `CLAUDE.md` carry only a fixed pointer block so committing them is safe.

**ORDER IS LOAD-BEARING.** `publish()` updates `.gitignore` FIRST, then writes the project-side handoff. Without that ordering, a concurrent `git add -A` in the sub-second gap could capture the handoff into a commit before git is told to ignore it.

Defense layers:
- **`write_owner_only`** — tempfile-then-rename with mode 0o600 set AT CREATION on unix (no TOCTOU window where the destination exists with the process umask before chmod is applied), plus belt-and-braces re-chmod after rename
- **`write_no_follow`** — same atomic pattern for committable files (AGENTS.md, CLAUDE.md, .gitignore) without forcing 0o600
- **Symlink rejection** on every destination via `symlink_metadata` + `file_type().is_symlink()` — closes the arbitrary-write primitive a malicious project-dir symlink would otherwise create
- **`.carryover/` directories** created with mode 0o700 on unix
- **Path traversal**: lexical `..` check → existence check → `canonicalize` → re-check so symlink-based traversal is closed too
- **Pointer block scanner is line-anchored**: literal markers inside documentation don't accidentally define a region
- **Dual-write integrity** uses `assert!` (not `debug_assert!`) so a release-build regression cannot silently emit divergent bytes

Public surface:
- `publish(distilled, ctx) -> PublishOutcome`
- `Distilled` struct with all 6 extractor outputs
- `POINTER_BLOCK` / `POINTER_START` / `POINTER_END` constants
- `MAX_HANDOFF_LINES = 50`, hard cap

33 tests including byte-identity dual-write, idempotent re-publish, 0o700 dir / 0o600 file mode assertions on unix, path traversal rejection (lexical + canonicalized), nonexistent project dir, fenced markdown not corrupted, **symlink rejection on every destination** (handoff.md, AGENTS.md, CLAUDE.md, .gitignore).

Test plan:
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (180 passed, 3 ignored — 177 unit + 3 integration)
- [x] cargo-deny check (advisories + bans + licenses + sources all ok)
- [x] gitignore-before-handoff ordering verified
- [x] Symlink rejection verified for all four destinations
- [x] No new dependencies