### PR TITLE
daemon: systemd-user unit + start/stop subcommands (Linux)

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -116,6 +116,20 @@ pub fn run() -> Result<()> {
     cfg.save(&cfg_path).context("save config")?;
     println!("Config saved to {}", cfg_path.display());
 
+    #[cfg(target_os = "linux")]
+    {
+        use crate::install::systemd;
+        match systemd::write_unit_file() {
+            Ok(path) => println!("Wrote systemd unit to {}", path.display()),
+            Err(e) => eprintln!("Could not write systemd unit: {e}"),
+        }
+        match systemd::enable_and_start() {
+            Ok(true) => println!("Daemon enabled and started via systemctl --user."),
+            Ok(false) => eprintln!("systemctl not available; daemon not auto-started."),
+            Err(e) => eprintln!("Could not enable/start daemon via systemctl: {e}"),
+        }
+    }
+
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,7 +8,9 @@ pub mod config;
 pub mod hooks_writer;
 pub mod install;
 pub mod refresh;
+pub mod start;
 pub mod status;
+pub mod stop;
 pub mod uninstall;
 
 #[derive(Parser, Debug)]
@@ -57,14 +59,8 @@ pub async fn run() -> Result<()> {
         Commands::Install => install::run().context("install failed"),
         Commands::Refresh => refresh::run().context("refresh failed"),
         Commands::Status => status::run().context("status failed"),
-        Commands::Start => {
-            eprintln!("not yet implemented: start (lands with the systemd unit PR)");
-            Ok(())
-        }
-        Commands::Stop => {
-            eprintln!("not yet implemented: stop (lands with the systemd unit PR)");
-            Ok(())
-        }
+        Commands::Start => start::run().await.context("start failed"),
+        Commands::Stop => stop::run().context("stop failed"),
         Commands::Uninstall { purge } => uninstall::run(purge).context("uninstall failed"),
     }
 }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -1,0 +1,99 @@
+//! `carryover start` — runs the daemon in the foreground.
+//!
+//! Spawns the hook endpoint (axum::serve on bind_loopback), the fs
+//! watcher (notify across all configured tool transcript roots), and a
+//! pipeline-stub worker that just drains the channels. The full
+//! pipeline (writes ledger rows, runs distillers, calls publish())
+//! lands in a follow-up PR; for v0.1 the stub keeps the channels
+//! healthy so the daemon survives the systemd-managed lifetime.
+//!
+//! Integration smoke tests belong in `tests/cross_tool.rs` (future PR)
+//! since they require binding a real port and spawning long-lived tasks.
+
+use anyhow::{Context, Result};
+use tokio::signal;
+use tokio::sync::mpsc::unbounded_channel;
+
+use crate::daemon::{fs_watcher::FsWatcher, hook_endpoint};
+
+pub async fn run() -> Result<()> {
+    println!("Carryover daemon starting...");
+
+    // Hook endpoint listener (bind 127.0.0.1:47823).
+    let listener = hook_endpoint::bind_loopback()
+        .await
+        .context("bind hook endpoint")?;
+    let local = listener.local_addr().context("local_addr")?;
+    println!("Hook endpoint listening on {local}");
+
+    // Worker channels.
+    let (hook_tx, mut hook_rx) = unbounded_channel::<hook_endpoint::HookEvent>();
+    let (watcher_tx, mut watcher_rx) = unbounded_channel::<crate::daemon::fs_watcher::WatchEvent>();
+
+    // Spawn fs watcher (best-effort — if no tool installed, log + continue).
+    let watcher = match FsWatcher::spawn_for_all_tools(watcher_tx) {
+        Ok(w) => {
+            println!("fs watcher subscribed to {} root(s)", w.roots.len());
+            Some(w)
+        }
+        Err(e) => {
+            eprintln!("fs watcher: not started ({e}); hook endpoint still active");
+            None
+        }
+    };
+
+    // Pipeline stub: drain both channels until shutdown. Future PRs
+    // wire this into adapters → ledger → distillers → publish.
+    let drain = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                Some(_evt) = hook_rx.recv() => {
+                    // TODO(daemon-pipeline): adapter dispatch + ledger write.
+                }
+                Some(_evt) = watcher_rx.recv() => {
+                    // TODO(daemon-pipeline): same as above for fs events.
+                }
+                else => break,
+            }
+        }
+    });
+
+    // axum serve, with graceful shutdown on Ctrl-C / SIGTERM.
+    let app = hook_endpoint::router(hook_tx);
+    let server = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
+    if let Err(e) = server.await {
+        eprintln!("hook endpoint server error: {e}");
+    }
+
+    drop(watcher);
+    drain.abort();
+    println!("Carryover daemon stopped.");
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c().await.ok();
+    };
+
+    #[cfg(unix)]
+    {
+        use signal::unix::{signal, SignalKind};
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(_) => {
+                ctrl_c.await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = ctrl_c => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        ctrl_c.await;
+    }
+}

--- a/src/cli/stop.rs
+++ b/src/cli/stop.rs
@@ -20,7 +20,7 @@ pub fn run() -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
 
@@ -28,7 +28,6 @@ mod tests {
     /// function returns Ok without panicking. Whether it returns true/false
     /// depends on the machine.
     #[test]
-    #[cfg(target_os = "linux")]
     fn stop_run_returns_ok() {
         // run() calls stop_only() which calls systemctl --user stop.
         // On a machine without a running carryoverd unit this still returns Ok.

--- a/src/cli/stop.rs
+++ b/src/cli/stop.rs
@@ -1,0 +1,38 @@
+//! `carryover stop` — sends SIGTERM via systemctl --user stop.
+
+use anyhow::Result;
+
+#[cfg(target_os = "linux")]
+pub fn run() -> Result<()> {
+    use crate::install::systemd;
+    let stopped = systemd::stop_only()?;
+    if stopped {
+        println!("Sent stop to carryoverd via systemctl --user.");
+    } else {
+        eprintln!("systemctl not available; nothing to stop.");
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn run() -> Result<()> {
+    eprintln!("`carryover stop` on this OS is deferred (see MAC_HANDOVER.md for macOS launchd).");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// systemctl is present on Linux CI runners; this test just checks the
+    /// function returns Ok without panicking. Whether it returns true/false
+    /// depends on the machine.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn stop_run_returns_ok() {
+        // run() calls stop_only() which calls systemctl --user stop.
+        // On a machine without a running carryoverd unit this still returns Ok.
+        let result = run();
+        assert!(result.is_ok(), "stop::run should not error: {result:?}");
+    }
+}

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -61,6 +61,21 @@ pub fn run(purge: bool) -> Result<()> {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    {
+        use crate::install::systemd;
+        match systemd::disable_and_stop() {
+            Ok(true) => println!("Daemon disabled and stopped via systemctl --user."),
+            Ok(false) => eprintln!("systemctl not available; daemon shutdown skipped."),
+            Err(e) => eprintln!("Could not disable/stop daemon: {e}"),
+        }
+        match systemd::remove_unit_file() {
+            Ok(true) => println!("Removed systemd unit file."),
+            Ok(false) => println!("systemd unit file already absent."),
+            Err(e) => eprintln!("Could not remove systemd unit file: {e}"),
+        }
+    }
+
     // Always remove config.json — its absence is the "not installed" signal.
     if cfg_path.exists() {
         std::fs::remove_file(&cfg_path)
@@ -104,7 +119,6 @@ pub fn run(purge: bool) -> Result<()> {
         }
     }
 
-    println!("Daemon registration removal: not yet implemented (lands with the systemd unit PR)");
     Ok(())
 }
 

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -1,0 +1,5 @@
+//! OS-level installation helpers — daemon registration via systemd-user
+//! on Linux, launchd on macOS (deferred to v0.1.x per MAC_HANDOVER.md).
+
+#[cfg(target_os = "linux")]
+pub mod systemd;

--- a/src/install/systemd.rs
+++ b/src/install/systemd.rs
@@ -1,0 +1,161 @@
+//! Linux systemd-user unit installer for `carryoverd`.
+//!
+//! Writes the unit file to ~/.config/systemd/user/carryoverd.service and
+//! optionally calls `systemctl --user enable --now carryoverd` /
+//! `systemctl --user disable --now carryoverd` to (un)register the daemon
+//! so it survives logout / login.
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use std::process::Command;
+
+const UNIT_FILE_NAME: &str = "carryoverd.service";
+
+/// Resolve `~/.config/systemd/user/carryoverd.service`.
+pub fn unit_file_path() -> Result<PathBuf> {
+    let config = dirs::config_dir().context("could not resolve $XDG_CONFIG_HOME or ~/.config")?;
+    Ok(config.join("systemd").join("user").join(UNIT_FILE_NAME))
+}
+
+/// Render the unit file body. The ExecStart path is the absolute path of
+/// the currently-running carryoverd binary (resolved via std::env::current_exe).
+pub fn render_unit() -> Result<String> {
+    let exe = std::env::current_exe()
+        .context("could not resolve carryoverd binary path for ExecStart")?;
+    let exe_str = exe.to_string_lossy();
+    Ok(format!(
+        r#"[Unit]
+Description=Carryover daemon — zero-LLM-token context-handoff
+After=default.target
+
+[Service]
+Type=simple
+ExecStart="{exe}" start
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"#,
+        exe = exe_str
+    ))
+}
+
+/// Write the unit file to disk. Returns the path written. Atomic write
+/// (tempfile + rename) so a crash mid-write leaves the prior unit intact.
+pub fn write_unit_file() -> Result<PathBuf> {
+    let path = unit_file_path()?;
+    let body = render_unit()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+
+    let dir = path.parent().context("unit file path has no parent")?;
+    let mut tmp = tempfile::NamedTempFile::new_in(dir).context("create temp unit file")?;
+    use std::io::Write as _;
+    tmp.write_all(body.as_bytes()).context("write temp unit")?;
+    tmp.as_file_mut().sync_all().context("sync temp unit")?;
+    tmp.persist(&path)
+        .map_err(|e| anyhow::anyhow!("{}", e))
+        .context("persist unit file")?;
+    Ok(path)
+}
+
+/// Run `systemctl --user enable --now carryoverd`. Tolerant of no-systemctl
+/// environments (CI containers): if systemctl isn't on PATH we return Ok(false).
+pub fn enable_and_start() -> Result<bool> {
+    if !systemctl_available()? {
+        return Ok(false);
+    }
+    let status = Command::new("systemctl")
+        .args(["--user", "enable", "--now", UNIT_FILE_NAME])
+        .status()
+        .context("invoke systemctl --user enable --now")?;
+    if !status.success() {
+        anyhow::bail!("systemctl --user enable --now failed: {status}");
+    }
+    Ok(true)
+}
+
+/// Run `systemctl --user disable --now carryoverd`. Tolerant of no-systemctl.
+pub fn disable_and_stop() -> Result<bool> {
+    if !systemctl_available()? {
+        return Ok(false);
+    }
+    let status = Command::new("systemctl")
+        .args(["--user", "disable", "--now", UNIT_FILE_NAME])
+        .status()
+        .context("invoke systemctl --user disable --now")?;
+    // disable on a non-installed unit returns nonzero; tolerate that.
+    let _ = status;
+    Ok(true)
+}
+
+/// Run `systemctl --user stop carryoverd`. Used by `carryover stop`.
+pub fn stop_only() -> Result<bool> {
+    if !systemctl_available()? {
+        return Ok(false);
+    }
+    let status = Command::new("systemctl")
+        .args(["--user", "stop", UNIT_FILE_NAME])
+        .status()
+        .context("invoke systemctl --user stop")?;
+    let _ = status;
+    Ok(true)
+}
+
+/// Remove the unit file from disk. Idempotent — missing file is fine.
+pub fn remove_unit_file() -> Result<bool> {
+    let path = unit_file_path()?;
+    if !path.exists() {
+        return Ok(false);
+    }
+    std::fs::remove_file(&path).with_context(|| format!("remove {}", path.display()))?;
+    Ok(true)
+}
+
+fn systemctl_available() -> Result<bool> {
+    Ok(Command::new("systemctl")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_file_path_under_xdg_config() {
+        let p = unit_file_path().unwrap();
+        let s = p.to_string_lossy();
+        assert!(s.ends_with("/systemd/user/carryoverd.service"), "got: {s}");
+    }
+
+    #[test]
+    fn render_unit_contains_expected_sections() {
+        let body = render_unit().unwrap();
+        assert!(body.contains("[Unit]"));
+        assert!(body.contains("[Service]"));
+        assert!(body.contains("[Install]"));
+        assert!(body.contains("ExecStart="));
+        assert!(body.contains("Restart=on-failure"));
+        assert!(body.contains("WantedBy=default.target"));
+    }
+
+    #[test]
+    fn render_unit_uses_current_exe_path() {
+        let exe = std::env::current_exe().unwrap();
+        let body = render_unit().unwrap();
+        let exe_str = exe.to_string_lossy();
+        assert!(body.contains(&*exe_str), "body should reference exe path");
+    }
+
+    #[test]
+    fn systemctl_available_returns_ok() {
+        // Just verify the helper returns Ok(_); true/false depends on the machine.
+        let result = systemctl_available();
+        assert!(result.is_ok(), "systemctl_available should not error");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod adapters;
 pub mod cli;
 pub mod daemon;
 pub mod distill;
+pub mod install;
 pub mod publish;
 pub mod storage;
 pub mod toolspec;


### PR DESCRIPTION
After this lands the daemon is fully runnable on Linux: `carryoverd install` registers it to start at login, `carryoverd start` runs the foreground process that systemd manages.

What this introduces:
- `src/install/systemd.rs` (Linux-only via `#[cfg(target_os = "linux")]`):
  - `unit_file_path` → `~/.config/systemd/user/carryoverd.service`
  - `render_unit` → `[Unit]`/`[Service]`/`[Install]` body with `Type=simple`, `Restart=on-failure`, `RestartSec=5`, `WantedBy=default.target`, and `ExecStart="<absolute carryoverd binary>" start` (path quoted so installs under directories with spaces parse correctly)
  - `write_unit_file` does an atomic tempfile + `sync_all` + rename
  - `enable_and_start` / `disable_and_stop` / `stop_only` / `remove_unit_file` shell out to `systemctl --user`. All four are tolerant of a missing `systemctl` (CI containers etc) — log + return `Ok(false)` rather than erroring.
- `src/cli/start.rs`: async daemon runner. `bind_loopback` for the hook endpoint, spawn `FsWatcher::spawn_for_all_tools` (best-effort), drain channels into a stub task (full pipeline lands in a follow-up), serve axum with `with_graceful_shutdown` that races Ctrl-C against SIGTERM via `tokio::signal` so systemd's stop is clean.
- `src/cli/stop.rs`: dispatches to `systemd::stop_only` on Linux; prints deferred-to-MAC_HANDOVER message on other OSes.
- `src/cli/install.rs`: after writing user config, on Linux only writes the unit file + `systemctl --user enable --now`.
- `src/cli/uninstall.rs`: on Linux only calls `systemctl --user disable --now` + removes the unit file BEFORE removing the user config.

macOS launchd is deferred to `MAC_HANDOVER.md`.

Test plan:
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (213 passed, 3 ignored — 210 unit + 3 integration)
- [x] cargo-deny check (advisories + bans + licenses + sources all ok)
- [x] `carryoverd --help` shows install / refresh / status / start / stop / uninstall
- [x] No new dependencies