### PR TITLE
homebrew: source-of-truth tap formula

### DIFF
--- a/homebrew-tap/Formula/carryover.rb
+++ b/homebrew-tap/Formula/carryover.rb
@@ -1,0 +1,76 @@
+# Homebrew formula for Carryover.
+#
+# This file is the source of truth for the carryover-dev/homebrew-tap
+# repository. Ship-day procedure (see MAC_HANDOVER.md):
+#
+#   1. Tag v0.1.0 in this repo so the Linux release workflow uploads
+#      the Linux binaries to the GitHub Release page.
+#   2. On a real Mac, build the macOS binaries (aarch64-apple-darwin
+#      and x86_64-apple-darwin), tar.gz them, and attach them to the
+#      same Release page.
+#   3. Compute the SHA-256 of each macOS tarball.
+#   4. Update the `version`, `sha256`, and `url` placeholders below.
+#   5. Copy this file to carryover-dev/homebrew-tap:Formula/carryover.rb
+#      and open a PR there.
+#
+# Until step 5 lands, `brew install carryover-dev/tap/carryover` does
+# not work. macOS users can install via npm in the meantime — they
+# just need the one-time `xattr -d com.apple.quarantine` workaround.
+
+class Carryover < Formula
+  desc "Zero-LLM-token context-handoff daemon — resume any AI session across Claude Code, Cursor, and Codex"
+  homepage "https://github.com/carryover-dev/carryover"
+  license "Apache-2.0"
+  version "0.1.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/carryover-dev/carryover/releases/download/v#{version}/carryoverd-v#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    on_intel do
+      url "https://github.com/carryover-dev/carryover/releases/download/v#{version}/carryoverd-v#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/carryover-dev/carryover/releases/download/v#{version}/carryoverd-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    on_intel do
+      url "https://github.com/carryover-dev/carryover/releases/download/v#{version}/carryoverd-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  def install
+    bin.install "carryoverd"
+  end
+
+  test do
+    # Smoke test: --help should print the subcommand list and exit 0.
+    output = shell_output("#{bin}/carryoverd --help")
+    assert_match "install", output
+    assert_match "refresh", output
+    assert_match "status", output
+    assert_match "uninstall", output
+  end
+
+  def caveats
+    <<~EOS
+      Carryover is signed with cosign (open-source) but NOT with an Apple
+      Developer ID. macOS Gatekeeper may still warn on first run; if it
+      does, run:
+
+        xattr -d com.apple.quarantine #{bin}/carryoverd
+
+      Apple Developer ID notarization is on the v1.0 roadmap.
+
+      To get started:
+
+        carryoverd install
+    EOS
+  end
+end

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -1,0 +1,35 @@
+# Carryover Homebrew tap (source-of-truth copy)
+
+This directory holds the canonical Homebrew formula for Carryover. The actual tap repo is at:
+
+> **https://github.com/carryover-dev/homebrew-tap**
+
+We keep the formula here too so:
+
+1. The formula and the binary it points at version together — when you tag `v0.1.0`, this file's URLs and SHAs are what go to the tap repo.
+2. PRs that change the install UX can edit one place and propagate.
+3. Anyone reading this repo can see exactly what `brew install carryover-dev/tap/carryover` will run.
+
+## Ship-day procedure
+
+When tagging a release, follow [`MAC_HANDOVER.md`](../MAC_HANDOVER.md) (lives in `~/workspace/carryover-context/v01-pilot/` — internal). The short version:
+
+1. Tag `v0.1.0` in this repo. The Linux release workflow uploads the Linux binaries to the GitHub Release page.
+2. On a real Mac, build the macOS binaries (`aarch64-apple-darwin` and `x86_64-apple-darwin`), tar them, attach to the same Release page.
+3. Compute SHA-256 for each tarball:
+   ```sh
+   shasum -a 256 carryoverd-v0.1.0-*.tar.gz
+   ```
+4. Update `Formula/carryover.rb` in this directory:
+   - bump `version`
+   - replace each `sha256 "0000…"` placeholder with the real hash
+5. Copy `Formula/carryover.rb` to `carryover-dev/homebrew-tap:Formula/carryover.rb` and open a PR there.
+6. Once that PR merges, `brew install carryover-dev/tap/carryover` works.
+
+## Why are the SHAs all zeros right now?
+
+This file ships before any release exists. The placeholders are deliberate — Homebrew refuses to install with a hash mismatch, so a stale `0000…` is the safe default; it forces the ship-day procedure to update the hashes before publishing.
+
+## License
+
+Apache-2.0. Same as the main project.


### PR DESCRIPTION
Adds the Homebrew formula that `carryover-dev/homebrew-tap` will mirror on ship day. Living in the main repo first so the formula and the binaries it points at version together, and so anyone reading this repo can see exactly what `brew install carryover-dev/tap/carryover` will run.

What this introduces:
- `homebrew-tap/Formula/carryover.rb`:
  - `on_macos { on_arm | on_intel }` + `on_linux { on_arm | on_intel }` — architecture-specific tarballs from this repo's Release page
  - SHA-256 placeholders are intentional zeros; Homebrew refuses install on hash mismatch so this is the safe default until ship-day updates them with real hashes
  - `install` step is `bin.install "carryoverd"`
  - `test` stanza smoke-tests `carryoverd --help` for the 4 CLI subcommands
  - `caveats` note documents the cosign vs Apple Developer ID gap and the one-time `xattr -d com.apple.quarantine` workaround
- `homebrew-tap/README.md`: ship-day procedure (sketch, full version in MAC_HANDOVER.md).

The tap doesn't actually work yet — the placeholders need real SHAs and the macOS binaries need to exist on the Release page first. The MAC_HANDOVER.md (internal) documents the procedure that fills these in and pushes to `carryover-dev/homebrew-tap`.

Apple Developer ID notarization stays on the v1.0 roadmap.

Test plan:
- [x] Ruby syntax check (`ruby -c Formula/carryover.rb`) passes
- [x] No Rust changes; cargo test untouched
- [x] No new dependencies
- [x] Placeholder SHA-256 of all-zeros prevents accidental install before ship-day fills it in