### PR TITLE
daemon: wire event pipeline — hook + fs events now reach ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +197,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "axum",
+ "chrono",
  "clap",
  "dialoguer",
  "dirs",
@@ -220,6 +230,20 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -278,6 +302,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "dialoguer"
@@ -586,6 +616,30 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1453,10 +1507,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ semver = "1"
 thiserror = "1"
 anyhow = "1"
 tempfile = "3"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "2.2.1"
 predicates = "3.1.4"
 tower = { version = "0.5", features = ["util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -1,20 +1,18 @@
 //! `carryover start` — runs the daemon in the foreground.
 //!
 //! Spawns the hook endpoint (axum::serve on bind_loopback), the fs
-//! watcher (notify across all configured tool transcript roots), and a
-//! pipeline-stub worker that just drains the channels. The full
-//! pipeline (writes ledger rows, runs distillers, calls publish())
-//! lands in a follow-up PR; for v0.1 the stub keeps the channels
-//! healthy so the daemon survives the systemd-managed lifetime.
-//!
-//! Integration smoke tests belong in `tests/cross_tool.rs` (future PR)
-//! since they require binding a real port and spawning long-lived tasks.
+//! watcher (notify across all configured tool transcript roots), and the
+//! pipeline worker that ingests events → ledger → distillers → handoff.
+
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use tokio::signal;
 use tokio::sync::mpsc::unbounded_channel;
 
-use crate::daemon::{fs_watcher::FsWatcher, hook_endpoint};
+use crate::cli::config::Config;
+use crate::daemon::{fs_watcher::FsWatcher, hook_endpoint, pipeline::Pipeline};
+use crate::storage::Ledger;
 
 pub async fn run() -> Result<()> {
     println!("Carryover daemon starting...");
@@ -28,7 +26,16 @@ pub async fn run() -> Result<()> {
 
     // Worker channels.
     let (hook_tx, mut hook_rx) = unbounded_channel::<hook_endpoint::HookEvent>();
-    let (watcher_tx, mut watcher_rx) = unbounded_channel::<crate::daemon::fs_watcher::WatchEvent>();
+    let (watcher_tx, mut watcher_rx) =
+        unbounded_channel::<crate::daemon::fs_watcher::WatchEvent>();
+
+    // Open ledger and build pipeline.
+    let ledger_path = Ledger::default_path().context("resolve ledger path")?;
+    let ledger = Ledger::open(&ledger_path).context("open ledger")?;
+    let config_path = Config::default_path().context("resolve config path")?;
+    let config = Config::load_or_default(&config_path).context("load config")?;
+    let home_dir = dirs::home_dir().context("resolve home directory")?;
+    let pipeline = Arc::new(Pipeline::build(&config, ledger, home_dir));
 
     // Spawn fs watcher (best-effort — if no tool installed, log + continue).
     let watcher = match FsWatcher::spawn_for_all_tools(watcher_tx) {
@@ -42,16 +49,16 @@ pub async fn run() -> Result<()> {
         }
     };
 
-    // Pipeline stub: drain both channels until shutdown. Future PRs
-    // wire this into adapters → ledger → distillers → publish.
+    // Pipeline drain: process hook and fs events until shutdown.
+    let pl = pipeline.clone();
     let drain = tokio::spawn(async move {
         loop {
             tokio::select! {
-                Some(_evt) = hook_rx.recv() => {
-                    // TODO(daemon-pipeline): adapter dispatch + ledger write.
+                Some(evt) = hook_rx.recv() => {
+                    pl.process_hook(&evt);
                 }
-                Some(_evt) = watcher_rx.recv() => {
-                    // TODO(daemon-pipeline): same as above for fs events.
+                Some(evt) = watcher_rx.recv() => {
+                    pl.process_watch(&evt);
                 }
                 else => break,
             }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -26,8 +26,7 @@ pub async fn run() -> Result<()> {
 
     // Worker channels.
     let (hook_tx, mut hook_rx) = unbounded_channel::<hook_endpoint::HookEvent>();
-    let (watcher_tx, mut watcher_rx) =
-        unbounded_channel::<crate::daemon::fs_watcher::WatchEvent>();
+    let (watcher_tx, mut watcher_rx) = unbounded_channel::<crate::daemon::fs_watcher::WatchEvent>();
 
     // Open ledger and build pipeline.
     let ledger_path = Ledger::default_path().context("resolve ledger path")?;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1,5 +1,6 @@
 //! Daemon lifecycle: hook endpoint on 127.0.0.1:47823 + fs watcher +
-//! pipeline worker. The fs watcher and pipeline worker are future PRs.
+//! pipeline worker.
 
 pub mod fs_watcher;
 pub mod hook_endpoint;
+pub mod pipeline;

--- a/src/daemon/pipeline.rs
+++ b/src/daemon/pipeline.rs
@@ -107,7 +107,8 @@ impl Pipeline {
 
         let rows: Vec<LedgerRow> = adapter.parse(raw_records)?;
         self.ledger.insert_batch(&rows)?;
-        self.ledger.save_cursor(tool, session_id, &new_cursor_json)?;
+        self.ledger
+            .save_cursor(tool, session_id, &new_cursor_json)?;
 
         self.distill_and_publish(tool, session_id, &rows)?;
         Ok(())
@@ -257,7 +258,8 @@ mod tests {
         assert!(cursor.is_some(), "cursor should be persisted after ingest");
         // Cursor JSON must deserialize back to a valid MockCursor.
         let cursor_json = cursor.unwrap();
-        let _: MockCursor = serde_json::from_str(&cursor_json).expect("cursor should be valid JSON");
+        let _: MockCursor =
+            serde_json::from_str(&cursor_json).expect("cursor should be valid JSON");
         drop(dir);
     }
 
@@ -324,10 +326,7 @@ mod tests {
             body.contains("# [CARRYOVER]"),
             "handoff should contain protocol title line"
         );
-        assert!(
-            body.len() > 20,
-            "handoff body should be non-trivially long"
-        );
+        assert!(body.len() > 20, "handoff body should be non-trivially long");
         drop(dir);
     }
 

--- a/src/daemon/pipeline.rs
+++ b/src/daemon/pipeline.rs
@@ -1,0 +1,349 @@
+//! Event-driven pipeline: hook events + fs-watcher events → adapter
+//! ingestion → ledger rows → distillation → handoff publish.
+//!
+//! The pipeline is the bridge that was missing in v0.1's initial build:
+//! events arrived at the daemon but were dropped before reaching adapters
+//! or the ledger.
+
+use std::collections::HashMap;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use chrono::Utc;
+use serde_json::json;
+
+use crate::adapters::AdapterKind;
+use crate::cli::config::Config;
+use crate::daemon::{fs_watcher::WatchEvent, hook_endpoint::HookEvent};
+use crate::distill::{
+    failed_approaches::extract_failed_approaches, git_context::extract_git_context,
+    next_action::extract_next_action, open_questions::extract_open_questions,
+    recent_files::extract_recent_files, task::extract_task,
+};
+use crate::publish::{publish, Distilled, PublishContext};
+use crate::storage::{Ledger, LedgerRow};
+
+/// Shared-state pipeline. Cheaply cloneable via the `Arc` on `Ledger`.
+pub struct Pipeline {
+    ledger: Ledger,
+    /// tool name → adapter instance
+    adapters: HashMap<String, AdapterKind>,
+    home_dir: PathBuf,
+    resume_mode: String,
+    /// Append-only audit log at `~/.carryover/events.jsonl`.
+    events_log: PathBuf,
+}
+
+impl Pipeline {
+    /// Build a pipeline from the user's config and an open ledger.
+    pub fn build(config: &Config, ledger: Ledger, home_dir: PathBuf) -> Self {
+        let adapters = build_adapter_map(&config.tools);
+        let events_log = home_dir.join(".carryover").join("events.jsonl");
+        Self {
+            ledger,
+            adapters,
+            home_dir,
+            resume_mode: config.resume_mode.clone(),
+            events_log,
+        }
+    }
+
+    /// Handle a hook POST from a tool (e.g. Claude SessionEnd).
+    pub fn process_hook(&self, evt: &HookEvent) {
+        let session_id = evt
+            .session_id
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
+        if let Err(e) = self.ingest(&evt.tool, &session_id, false) {
+            self.log_error(&evt.tool, &session_id, &format!("{e:#}"));
+        }
+    }
+
+    /// Handle an fs-watcher event (transcript file changed).
+    ///
+    /// When `evt.rescan` is true (inotify overflow / FSEvents coalesce per
+    /// decisions.md research finding 3), reset every adapter's cursor so
+    /// the next ingest is a full re-read.
+    pub fn process_watch(&self, evt: &WatchEvent) {
+        if evt.rescan {
+            // Reset all cursors; a rescan may have missed events for any tool.
+            for tool in self.adapters.keys() {
+                if let Err(e) = self.ledger.save_cursor(tool, "default", "") {
+                    self.log_error(tool, "default", &format!("cursor reset failed: {e:#}"));
+                }
+            }
+        }
+
+        // Ingest all configured adapters — each adapter reads from its own
+        // paths and returns nothing if those paths haven't changed.
+        for tool in self.adapters.keys() {
+            if let Err(e) = self.ingest(tool, "default", evt.rescan) {
+                self.log_error(tool, "default", &format!("{e:#}"));
+            }
+        }
+    }
+
+    /// Core ingest: load cursor → read new records → parse → insert → advance
+    /// cursor → distill → publish.
+    fn ingest(&self, tool: &str, session_id: &str, force_rescan: bool) -> Result<()> {
+        let adapter = match self.adapters.get(tool) {
+            Some(a) => a,
+            None => return Ok(()), // tool not in config
+        };
+
+        let cursor_json = if force_rescan {
+            String::new()
+        } else {
+            self.ledger
+                .load_cursor(tool, session_id)?
+                .unwrap_or_default()
+        };
+
+        let (raw_records, new_cursor_json) = adapter.read_new_records_erased(&cursor_json)?;
+        if raw_records.is_empty() {
+            return Ok(());
+        }
+
+        let rows: Vec<LedgerRow> = adapter.parse(raw_records)?;
+        self.ledger.insert_batch(&rows)?;
+        self.ledger.save_cursor(tool, session_id, &new_cursor_json)?;
+
+        self.distill_and_publish(tool, session_id, &rows)?;
+        Ok(())
+    }
+
+    fn distill_and_publish(&self, tool: &str, session_id: &str, rows: &[LedgerRow]) -> Result<()> {
+        let distilled = Distilled {
+            source_tool: tool.to_string(),
+            session_id: session_id.to_string(),
+            timestamp_iso: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            task: extract_task(rows),
+            open_questions: extract_open_questions(rows),
+            next_action: extract_next_action(rows),
+            recent_files: extract_recent_files(rows),
+            failed_approaches: extract_failed_approaches(rows),
+            git_context: extract_git_context(rows, Some(Path::new(&self.home_dir))),
+        };
+
+        let ctx = PublishContext {
+            home_dir: self.home_dir.clone(),
+            // v0.1: write to home dir (global handoff).
+            // Per-project dir requires CWD in hook payload — future PR.
+            project_dir: self.home_dir.clone(),
+            resume_mode: self.resume_mode.clone(),
+        };
+
+        publish(&distilled, &ctx)?;
+        Ok(())
+    }
+
+    fn log_error(&self, tool: &str, session_id: &str, message: &str) {
+        let entry = json!({
+            "ts": Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            "level": "error",
+            "tool": tool,
+            "session_id": session_id,
+            "message": message,
+        });
+        let line = format!("{}\n", entry);
+        let _ = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.events_log)
+            .and_then(|mut f| f.write_all(line.as_bytes()));
+    }
+}
+
+fn build_adapter_map(tools: &[String]) -> HashMap<String, AdapterKind> {
+    let mut map = HashMap::new();
+    for tool in tools {
+        let kind = match tool.as_str() {
+            "claude" => Some(AdapterKind::Claude(
+                crate::adapters::claude::ClaudeAdapter::new(),
+            )),
+            "cursor" => Some(AdapterKind::Cursor(
+                crate::adapters::cursor::CursorAdapter::new(),
+            )),
+            "codex" => Some(AdapterKind::Codex(
+                crate::adapters::codex::CodexAdapter::new(),
+            )),
+            _ => None,
+        };
+        if let Some(k) = kind {
+            map.insert(tool.clone(), k);
+        }
+    }
+    map
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Construct a Pipeline with a caller-supplied adapter map.
+/// Intended for tests only — not part of the public stable API.
+pub fn build_for_test(
+    adapters: HashMap<String, AdapterKind>,
+    ledger: Ledger,
+    home_dir: PathBuf,
+) -> Pipeline {
+    let events_log = home_dir.join(".carryover").join("events.jsonl");
+    Pipeline {
+        ledger,
+        adapters,
+        home_dir,
+        resume_mode: "ask".to_string(),
+        events_log,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::mock::{MockAdapter, MockCursor};
+    use crate::adapters::RawRecord;
+    use crate::storage::LedgerRow;
+    use tempfile::tempdir;
+
+    /// A `RawRecord` whose payload is a valid JSON-serialized `LedgerRow`.
+    fn mock_record(tool: &str, offset: u64) -> RawRecord {
+        let row = LedgerRow {
+            session_id: "test-session".to_string(),
+            tool: tool.to_string(),
+            ts: offset as i64 * 1000,
+            role: "user".to_string(),
+            content: format!("turn {offset}"),
+            tool_calls_json: None,
+            files_touched_json: None,
+            parent_id: None,
+        };
+        RawRecord {
+            tool: tool.to_string(),
+            payload: serde_json::to_vec(&row).unwrap(),
+            offset,
+        }
+    }
+
+    fn test_pipeline() -> (Pipeline, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(&dir.path().join("ledger.sqlite")).unwrap();
+        let home = dir.path().to_path_buf();
+        let adapter = MockAdapter {
+            name: "mock",
+            binary: None,
+            records: vec![mock_record("mock", 1), mock_record("mock", 2)],
+        };
+        let mut adapters = HashMap::new();
+        adapters.insert("mock".to_string(), AdapterKind::Mock(adapter));
+        let p = build_for_test(adapters, ledger, home);
+        (p, dir)
+    }
+
+    #[test]
+    fn ingest_mock_produces_ledger_rows() {
+        let (pipeline, dir) = test_pipeline();
+        pipeline.ingest("mock", "session-1", false).unwrap();
+        let rows = pipeline.ledger.query_recent("mock", 100).unwrap();
+        assert!(
+            !rows.is_empty(),
+            "expected ledger rows after mock ingest, got 0"
+        );
+        let cursor = pipeline.ledger.load_cursor("mock", "session-1").unwrap();
+        assert!(cursor.is_some(), "cursor should be persisted after ingest");
+        // Cursor JSON must deserialize back to a valid MockCursor.
+        let cursor_json = cursor.unwrap();
+        let _: MockCursor = serde_json::from_str(&cursor_json).expect("cursor should be valid JSON");
+        drop(dir);
+    }
+
+    #[test]
+    fn ingest_unknown_tool_is_noop() {
+        let (pipeline, dir) = test_pipeline();
+        pipeline.ingest("unknown", "s1", false).unwrap();
+        assert_eq!(
+            pipeline.ledger.query_recent("unknown", 10).unwrap().len(),
+            0
+        );
+        drop(dir);
+    }
+
+    #[test]
+    fn ingest_idempotent_after_cursor_advance() {
+        // Second ingest with an advanced cursor should return 0 new rows.
+        let (pipeline, dir) = test_pipeline();
+        pipeline.ingest("mock", "s1", false).unwrap();
+        let count_after_first = pipeline.ledger.query_recent("mock", 100).unwrap().len();
+        pipeline.ingest("mock", "s1", false).unwrap();
+        let count_after_second = pipeline.ledger.query_recent("mock", 100).unwrap().len();
+        assert_eq!(
+            count_after_first, count_after_second,
+            "second ingest should insert 0 new rows (cursor advanced)"
+        );
+        drop(dir);
+    }
+
+    #[test]
+    fn force_rescan_re_reads_from_start() {
+        let (pipeline, dir) = test_pipeline();
+        pipeline.ingest("mock", "s1", false).unwrap();
+        let count_after_normal = pipeline.ledger.query_recent("mock", 100).unwrap().len();
+        // Force rescan: resets cursor then re-reads all records.
+        pipeline.ingest("mock", "s1", true).unwrap();
+        let count_after_rescan = pipeline.ledger.query_recent("mock", 100).unwrap().len();
+        // Rescan should produce ≥ as many rows as the first ingest.
+        assert!(
+            count_after_rescan >= count_after_normal,
+            "rescan should produce at least as many rows as initial ingest"
+        );
+        drop(dir);
+    }
+
+    #[test]
+    fn distill_and_publish_writes_handoff() {
+        let (pipeline, dir) = test_pipeline();
+        let rows = vec![LedgerRow {
+            session_id: "s1".to_string(),
+            tool: "mock".to_string(),
+            ts: 1_000_000,
+            role: "user".to_string(),
+            content: "working on the login feature".to_string(),
+            tool_calls_json: None,
+            files_touched_json: None,
+            parent_id: None,
+        }];
+        pipeline.distill_and_publish("mock", "s1", &rows).unwrap();
+        let handoff = dir.path().join(".carryover").join("handoff.md");
+        assert!(handoff.exists(), "handoff.md should be written");
+        let body = std::fs::read_to_string(&handoff).unwrap();
+        assert!(
+            body.contains("# [CARRYOVER]"),
+            "handoff should contain protocol title line"
+        );
+        assert!(
+            body.len() > 20,
+            "handoff body should be non-trivially long"
+        );
+        drop(dir);
+    }
+
+    #[test]
+    fn process_hook_end_to_end() {
+        let (pipeline, dir) = test_pipeline();
+        let evt = HookEvent {
+            tool: "mock".to_string(),
+            event: "SessionEnd".to_string(),
+            transcript_path: None,
+            session_id: Some("hook-session".to_string()),
+            extra: serde_json::Map::new(),
+        };
+        pipeline.process_hook(&evt);
+        let rows = pipeline.ledger.query_recent("mock", 100).unwrap();
+        assert!(!rows.is_empty(), "process_hook should produce ledger rows");
+        drop(dir);
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -224,6 +224,43 @@ impl Ledger {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(rows)
     }
+
+    /// Upsert cursor JSON for `(tool, session_id)`. The cursor is an opaque
+    /// JSON blob owned by the adapter; the ledger stores and retrieves it
+    /// without interpreting its contents.
+    pub fn save_cursor(
+        &self,
+        tool: &str,
+        session_id: &str,
+        cursor_json: &str,
+    ) -> Result<(), StorageError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO cursors (tool, session_id, cursor_json)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(tool, session_id) DO UPDATE SET cursor_json = excluded.cursor_json",
+            params![tool, session_id, cursor_json],
+        )?;
+        Ok(())
+    }
+
+    /// Load the stored cursor JSON for `(tool, session_id)`.
+    /// Returns `None` if no cursor has been saved yet (first run).
+    pub fn load_cursor(
+        &self,
+        tool: &str,
+        session_id: &str,
+    ) -> Result<Option<String>, StorageError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare_cached(
+            "SELECT cursor_json FROM cursors WHERE tool = ?1 AND session_id = ?2",
+        )?;
+        match stmt.query_row(params![tool, session_id], |row| row.get::<_, String>(0)) {
+            Ok(s) => Ok(Some(s)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(StorageError::Sqlite(e)),
+        }
+    }
 }
 
 /// Map a rusqlite `Row` to a `LedgerRow`.

--- a/tests/daemon_e2e.rs
+++ b/tests/daemon_e2e.rs
@@ -1,0 +1,132 @@
+//! End-to-end daemon integration test.
+//!
+//! Uses `tower::ServiceExt::oneshot` to send a synthetic HTTP request
+//! directly into the axum router — no TCP socket needed. Verifies the
+//! full path: HTTP request → hook channel → pipeline ingest → ledger
+//! rows → handoff.md written.
+
+use std::collections::HashMap;
+
+use axum::body::Body;
+use carryover::adapters::mock::{MockAdapter, MockCursor};
+use carryover::adapters::{AdapterKind, RawRecord};
+use carryover::daemon::hook_endpoint;
+use carryover::daemon::pipeline::build_for_test;
+use carryover::storage::{Ledger, LedgerRow};
+use axum::http::Request;
+use tokio::sync::mpsc::unbounded_channel;
+use tower::ServiceExt as _;
+
+fn mock_record(offset: u64) -> RawRecord {
+    let row = LedgerRow {
+        session_id: "e2e-session".to_string(),
+        tool: "claude".to_string(),
+        ts: offset as i64 * 1000,
+        role: "user".to_string(),
+        content: format!("e2e turn {offset}"),
+        tool_calls_json: None,
+        files_touched_json: None,
+        parent_id: None,
+    };
+    RawRecord {
+        tool: "claude".to_string(),
+        payload: serde_json::to_vec(&row).unwrap(),
+        offset,
+    }
+}
+
+#[tokio::test]
+async fn hook_post_produces_ledger_rows_and_handoff() {
+    let dir = tempfile::tempdir().unwrap();
+    let ledger = Ledger::open(&dir.path().join("ledger.sqlite")).unwrap();
+
+    // Register MockAdapter under "claude" so the hook endpoint's KNOWN_TOOLS
+    // check passes, while still using synthetic in-memory records.
+    let adapter = MockAdapter {
+        name: "claude",
+        binary: None,
+        records: vec![mock_record(1), mock_record(2), mock_record(3)],
+    };
+    let mut adapters = HashMap::new();
+    adapters.insert("claude".to_string(), AdapterKind::Mock(adapter));
+    let pipeline = build_for_test(adapters, ledger.clone(), dir.path().to_path_buf());
+
+    // Build the axum router with a channel.
+    let (hook_tx, mut hook_rx) = unbounded_channel::<hook_endpoint::HookEvent>();
+    let app = hook_endpoint::router(hook_tx);
+
+    // Send a POST /hook/mock/SessionEnd directly via oneshot (no TCP needed).
+    let request = Request::builder()
+        .method("POST")
+        .uri("/hook/claude/SessionEnd")
+        .header("host", "127.0.0.1:47823")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"session_id":"e2e-session"}"#))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert!(
+        response.status().is_success(),
+        "hook endpoint should return 2xx, got {}",
+        response.status()
+    );
+
+    // Receive the event from the channel (the router sends it synchronously).
+    let evt = hook_rx
+        .try_recv()
+        .expect("hook event should be in channel after successful POST");
+    assert_eq!(evt.tool, "claude");
+    assert_eq!(evt.event, "SessionEnd");
+
+    // Drive the pipeline directly.
+    pipeline.process_hook(&evt);
+
+    // Assert ledger received rows.
+    let rows = ledger.query_recent("claude", 100).unwrap();
+    assert!(
+        !rows.is_empty(),
+        "expected ledger rows after process_hook, got 0"
+    );
+
+    // Assert every row has required fields.
+    for row in &rows {
+        assert_eq!(row.tool, "claude");
+        assert!(!row.session_id.is_empty());
+        assert!(!row.role.is_empty());
+        assert!(row.ts > 0);
+    }
+
+    // Assert cursor was persisted.
+    let cursor_json = ledger
+        .load_cursor("claude", "e2e-session")
+        .unwrap();
+    assert!(cursor_json.is_some(), "cursor should be persisted");
+    let _: MockCursor = serde_json::from_str(&cursor_json.unwrap())
+        .expect("cursor should deserialize as MockCursor");
+
+    // Assert handoff.md was written and has the protocol header.
+    let handoff = dir.path().join(".carryover").join("handoff.md");
+    assert!(handoff.exists(), "handoff.md should be written after ingest");
+    let body = std::fs::read_to_string(&handoff).unwrap();
+    assert!(
+        body.contains("# [CARRYOVER]"),
+        "handoff should have protocol title"
+    );
+    assert!(
+        body.contains("claude"),
+        "handoff should mention source tool"
+    );
+}
+
+#[tokio::test]
+async fn hook_health_endpoint_returns_ok() {
+    let (hook_tx, _hook_rx) = unbounded_channel::<hook_endpoint::HookEvent>();
+    let app = hook_endpoint::router(hook_tx);
+    let request = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .header("host", "127.0.0.1:47823")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert!(response.status().is_success());
+}

--- a/tests/daemon_e2e.rs
+++ b/tests/daemon_e2e.rs
@@ -8,12 +8,12 @@
 use std::collections::HashMap;
 
 use axum::body::Body;
+use axum::http::Request;
 use carryover::adapters::mock::{MockAdapter, MockCursor};
 use carryover::adapters::{AdapterKind, RawRecord};
 use carryover::daemon::hook_endpoint;
 use carryover::daemon::pipeline::build_for_test;
 use carryover::storage::{Ledger, LedgerRow};
-use axum::http::Request;
 use tokio::sync::mpsc::unbounded_channel;
 use tower::ServiceExt as _;
 
@@ -96,16 +96,17 @@ async fn hook_post_produces_ledger_rows_and_handoff() {
     }
 
     // Assert cursor was persisted.
-    let cursor_json = ledger
-        .load_cursor("claude", "e2e-session")
-        .unwrap();
+    let cursor_json = ledger.load_cursor("claude", "e2e-session").unwrap();
     assert!(cursor_json.is_some(), "cursor should be persisted");
     let _: MockCursor = serde_json::from_str(&cursor_json.unwrap())
         .expect("cursor should deserialize as MockCursor");
 
     // Assert handoff.md was written and has the protocol header.
     let handoff = dir.path().join(".carryover").join("handoff.md");
-    assert!(handoff.exists(), "handoff.md should be written after ingest");
+    assert!(
+        handoff.exists(),
+        "handoff.md should be written after ingest"
+    );
     let body = std::fs::read_to_string(&handoff).unwrap();
     assert!(
         body.contains("# [CARRYOVER]"),


### PR DESCRIPTION
## Summary

- Implements `src/daemon/pipeline.rs`: the Pipeline struct that drains HookEvent + WatchEvent into adapter ingestion → LedgerRow inserts → distillation → handoff.md publish
- Adds `Ledger::save_cursor` / `load_cursor` (cursors table existed in migrations; methods were missing)  
- Replaces the two `TODO(daemon-pipeline)` stubs in `start.rs` with real pipeline calls
- Adds `tests/daemon_e2e.rs`: end-to-end test via `tower::oneshot` — POST → channel → pipeline → ledger rows + handoff.md
- Adds `chrono 0.4` for UTC timestamp formatting

This was discovered during Linux dogfood: `carryoverd status` showed `Ledger: 0 bytes` because every incoming event was silently dropped. The cross-tool integration test bypassed the daemon main loop, so the stub passed CI.

## Test plan

- [ ] `cargo test --all-features --no-fail-fast` — all 225 tests pass
- [ ] `cargo install --path . --locked && systemctl --user restart carryoverd` — daemon starts, binds 47823, subscribes 3 fs roots
- [ ] `carryoverd status` shows ledger row count after a real Claude session ends