### PR TITLE
fix(codex): wire notify array + AGENTS.md pointer block on install/uninstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "toml_edit",
  "tower",
 ]
 
@@ -1298,6 +1299,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1738,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "1"
 anyhow = "1"
 tempfile = "3"
 chrono = { version = "0.4", features = ["serde"] }
+toml_edit = "0.22"
 
 [dev-dependencies]
 assert_cmd = "2.2.1"

--- a/src/cli/hooks_writer.rs
+++ b/src/cli/hooks_writer.rs
@@ -7,7 +7,7 @@
 //!   be an array of matcher objects: `[{"matcher":"","hooks":[{"type":"command","command":"..."}]}]`
 //! - Cursor:      ~/.cursor/hooks.json     — JSON, hooks under "<eventName>"
 //!   as `{ "command": "...", "version": 1 }` objects. (Cursor B5 fix: TODO)
-//! - Codex:       ~/.codex/config.toml     — TOML; v0.1 SKIPS Codex stub writing.
+//! - Codex:       ~/.codex/config.toml     — TOML, `notify` array + AGENTS.md pointer
 
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -318,6 +318,141 @@ pub fn remove_cursor_hooks(path: &Path, events: &[&str]) -> Result<bool> {
     }
     write_json_atomic(path, &Value::Object(map))?;
     Ok(true)
+}
+
+/// Path of the Codex notify wrapper script.
+pub fn codex_wrapper_path(home: &Path) -> std::path::PathBuf {
+    home.join(".carryover")
+        .join("hooks")
+        .join("codex-notify.sh")
+}
+
+fn codex_wrapper_script() -> String {
+    format!(
+        "#!/usr/bin/env sh\nINPUT=$(cat)\ncurl -X POST -s -H 'Content-Type: application/json' \\\n  -d \"$INPUT\" http://127.0.0.1:{LOOPBACK_PORT}/hook/codex/turnEnd > /dev/null 2>&1\n"
+    )
+}
+
+/// Write the Codex notify wrapper script to `~/.carryover/hooks/codex-notify.sh`.
+pub fn write_codex_wrapper_script(home: &Path) -> Result<bool> {
+    let path = codex_wrapper_path(home);
+    let content = codex_wrapper_script();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context("create hooks dir")?;
+    }
+    let needs_write = match std::fs::read_to_string(&path) {
+        Ok(existing) => existing != content,
+        Err(_) => true,
+    };
+    if !needs_write {
+        return Ok(false);
+    }
+    reject_symlink(&path)?;
+    std::fs::write(&path, &content).context("write codex notify script")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .context("chmod codex notify script")?;
+    }
+    Ok(true)
+}
+
+/// Write `notify = ["<wrapper-script>"]` into `~/.codex/config.toml`.
+///
+/// Uses `toml_edit` to preserve all existing comments and keys.
+/// Idempotent: if our wrapper path is already in the `notify` array, no-op.
+/// Returns `true` if the file was modified.
+pub fn write_codex_notify(config_path: &Path, home: &Path) -> Result<bool> {
+    use toml_edit::{Array, DocumentMut, Item, Value as TomlValue};
+
+    let wrapper = codex_wrapper_path(home);
+    let wrapper_str = wrapper.to_string_lossy().into_owned();
+
+    let raw = match std::fs::read_to_string(config_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e).context("read codex config.toml"),
+    };
+
+    let mut doc: DocumentMut = raw.parse().context("parse codex config.toml as TOML")?;
+
+    // Check if our wrapper is already in the notify array.
+    let already_present = doc
+        .get("notify")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().any(|v| v.as_str() == Some(wrapper_str.as_str())))
+        .unwrap_or(false);
+
+    if already_present {
+        return Ok(false);
+    }
+
+    // Get or create the notify array, then append our wrapper.
+    match doc.get_mut("notify") {
+        Some(Item::Value(TomlValue::Array(arr))) => {
+            arr.push(wrapper_str.as_str());
+        }
+        None => {
+            let mut arr = Array::new();
+            arr.push(wrapper_str.as_str());
+            doc["notify"] = toml_edit::value(arr);
+        }
+        Some(other) => {
+            // notify exists but is not an array — replace with our array.
+            let _ = other;
+            let mut arr = Array::new();
+            arr.push(wrapper_str.as_str());
+            doc["notify"] = toml_edit::value(arr);
+        }
+    }
+
+    reject_symlink(config_path)?;
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent).context("create codex config dir")?;
+    }
+    std::fs::write(config_path, doc.to_string()).context("write codex config.toml")?;
+    Ok(true)
+}
+
+/// Remove our wrapper from the `notify` array in `~/.codex/config.toml`.
+/// Returns `true` if the file was modified.
+pub fn remove_codex_notify(config_path: &Path, home: &Path) -> Result<bool> {
+    use toml_edit::{DocumentMut, Item, Value as TomlValue};
+
+    let wrapper = codex_wrapper_path(home);
+    let wrapper_str = wrapper.to_string_lossy().into_owned();
+
+    let raw = match std::fs::read_to_string(config_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e).context("read codex config.toml"),
+    };
+
+    let mut doc: DocumentMut = raw.parse().context("parse codex config.toml as TOML")?;
+
+    if let Some(Item::Value(TomlValue::Array(arr))) = doc.get_mut("notify") {
+        let before = arr.len();
+        // Build a new array without our entry.
+        let keep: Vec<String> = arr
+            .iter()
+            .filter(|v| v.as_str() != Some(wrapper_str.as_str()))
+            .map(|v| v.as_str().unwrap_or("").to_string())
+            .collect();
+        if keep.len() == before {
+            return Ok(false);
+        }
+        let mut new_arr = toml_edit::Array::new();
+        for s in &keep {
+            new_arr.push(s.as_str());
+        }
+        *arr = new_arr;
+        reject_symlink(config_path)?;
+        std::fs::write(config_path, doc.to_string()).context("write codex config.toml")?;
+        return Ok(true);
+    }
+
+    Ok(false)
 }
 
 fn write_json_atomic(path: &Path, value: &Value) -> Result<()> {
@@ -660,5 +795,94 @@ mod tests {
         let p = dir.path().join("hooks.json");
         let result = remove_cursor_hooks(&p, &["beforeSubmitPrompt"]).unwrap();
         assert!(!result);
+    }
+
+    // ---- write_codex_notify / remove_codex_notify -------------------------
+
+    #[test]
+    fn write_codex_notify_creates_config_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let config = home.join(".codex").join("config.toml");
+
+        let first = write_codex_notify(&config, home).unwrap();
+        assert!(first, "first call should create file");
+
+        let raw = std::fs::read_to_string(&config).unwrap();
+        let wrapper = codex_wrapper_path(home);
+        assert!(
+            raw.contains(&*wrapper.to_string_lossy()),
+            "notify should contain our wrapper path"
+        );
+
+        let second = write_codex_notify(&config, home).unwrap();
+        assert!(!second, "second call should be no-op");
+    }
+
+    #[test]
+    fn write_codex_notify_preserves_existing_keys_and_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let config = home.join("config.toml");
+        std::fs::write(&config, "# my codex config\nsome_key = \"value\"\n").unwrap();
+
+        write_codex_notify(&config, home).unwrap();
+
+        let raw = std::fs::read_to_string(&config).unwrap();
+        assert!(raw.contains("# my codex config"), "comment preserved");
+        assert!(raw.contains("some_key"), "existing key preserved");
+        assert!(raw.contains("notify"), "notify key added");
+    }
+
+    #[test]
+    fn write_codex_notify_appends_to_existing_notify_array() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let config = home.join("config.toml");
+        std::fs::write(&config, "notify = [\"other-script.sh\"]\n").unwrap();
+
+        write_codex_notify(&config, home).unwrap();
+
+        let raw = std::fs::read_to_string(&config).unwrap();
+        assert!(raw.contains("other-script.sh"), "existing entry preserved");
+        let wrapper = codex_wrapper_path(home);
+        assert!(raw.contains(&*wrapper.to_string_lossy()), "our entry added");
+    }
+
+    #[test]
+    fn remove_codex_notify_removes_our_entry_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let config = home.join("config.toml");
+        std::fs::write(&config, "notify = [\"other-script.sh\"]\n").unwrap();
+
+        write_codex_notify(&config, home).unwrap();
+        let removed = remove_codex_notify(&config, home).unwrap();
+        assert!(removed, "should report modification");
+
+        let raw = std::fs::read_to_string(&config).unwrap();
+        assert!(raw.contains("other-script.sh"), "foreign entry preserved");
+        let wrapper = codex_wrapper_path(home);
+        assert!(
+            !raw.contains(&*wrapper.to_string_lossy()),
+            "our entry removed"
+        );
+    }
+
+    #[test]
+    fn write_codex_wrapper_script_is_idempotent_and_contains_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+
+        let first = write_codex_wrapper_script(home).unwrap();
+        assert!(first);
+        let second = write_codex_wrapper_script(home).unwrap();
+        assert!(!second, "idempotent");
+
+        let content = std::fs::read_to_string(codex_wrapper_path(home)).unwrap();
+        assert!(
+            content.contains("/hook/codex/turnEnd"),
+            "script must POST to turnEnd"
+        );
     }
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use super::config::Config;
 use super::hooks_writer;
+use crate::publish::ensure_pointer_block;
 use crate::toolspec::specs::ALL_TOOLS;
 
 pub fn run() -> Result<()> {
@@ -97,9 +98,20 @@ pub fn run() -> Result<()> {
                     .with_context(|| format!("write cursor hooks to {}", config_path.display()))?
             }
             "codex" => {
-                // TODO(codex-toml): wire up after toml crate lands in a follow-up PR.
-                eprintln!("  codex: skipping hook stub write (TOML editing lands in a follow-up)");
-                false
+                hooks_writer::write_codex_wrapper_script(&home)
+                    .with_context(|| "write codex notify script")?;
+                let notify_modified = hooks_writer::write_codex_notify(&config_path, &home)
+                    .with_context(|| format!("write codex notify to {}", config_path.display()))?;
+                // Pointer blocks: ~/.codex/AGENTS.md, ~/AGENTS.md, ~/CLAUDE.md
+                for md in &[
+                    home.join(".codex").join("AGENTS.md"),
+                    home.join("AGENTS.md"),
+                    home.join("CLAUDE.md"),
+                ] {
+                    ensure_pointer_block(md)
+                        .with_context(|| format!("write pointer block to {}", md.display()))?;
+                }
+                notify_modified
             }
             _ => false,
         };

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 
 use super::config::Config;
 use super::hooks_writer;
+use crate::publish::remove_pointer_block;
 use crate::toolspec::specs::ALL_TOOLS;
 
 pub fn run(purge: bool) -> Result<()> {
@@ -54,6 +55,21 @@ pub fn run(purge: bool) -> Result<()> {
                 hooks_writer::remove_cursor_hooks(&config_path, &events).with_context(|| {
                     format!("remove cursor hooks from {}", config_path.display())
                 })?
+            }
+            "codex" => {
+                let notify_removed = hooks_writer::remove_codex_notify(&config_path, &home)
+                    .with_context(|| {
+                        format!("remove codex notify from {}", config_path.display())
+                    })?;
+                for md in &[
+                    home.join(".codex").join("AGENTS.md"),
+                    home.join("AGENTS.md"),
+                    home.join("CLAUDE.md"),
+                ] {
+                    remove_pointer_block(md)
+                        .with_context(|| format!("remove pointer block from {}", md.display()))?;
+                }
+                notify_removed
             }
             _ => false,
         };

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -20,7 +20,9 @@ mod pointer;
 mod write_atomic;
 
 pub use handoff::{render_handoff, Distilled, MAX_HANDOFF_LINES};
-pub use pointer::{POINTER_BLOCK, POINTER_END, POINTER_START};
+pub use pointer::{
+    ensure_pointer_block, remove_pointer_block, POINTER_BLOCK, POINTER_END, POINTER_START,
+};
 
 use std::path::{Path, PathBuf};
 use thiserror::Error;

--- a/src/publish/pointer.rs
+++ b/src/publish/pointer.rs
@@ -58,6 +58,33 @@ pub fn ensure_pointer_block(path: &Path) -> std::io::Result<bool> {
     Ok(true)
 }
 
+/// Remove the Carryover pointer block from `path` if present.
+/// Returns true if the file was modified. No-ops if the file does not exist
+/// or the block was not found.
+pub fn remove_pointer_block(path: &Path) -> std::io::Result<bool> {
+    let existing = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e),
+    };
+    let Some((start, end)) = find_block_bounds(&existing) else {
+        return Ok(false);
+    };
+    let before = existing[..start].trim_end_matches('\n');
+    let after = &existing[end..];
+    let new_content = if after.trim().is_empty() {
+        if before.is_empty() {
+            String::new()
+        } else {
+            format!("{before}\n")
+        }
+    } else {
+        format!("{before}\n{after}")
+    };
+    write_atomic::write_no_follow(path, new_content.as_bytes())?;
+    Ok(true)
+}
+
 fn build_new_content(existing: &str) -> String {
     if let Some((start_byte, end_byte)) = find_block_bounds(existing) {
         let before = &existing[..start_byte];
@@ -203,5 +230,40 @@ mod tests {
         let err = ensure_pointer_block(&link).expect_err("symlink target must be rejected");
         assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
         assert_eq!(fs::read_to_string(&real).unwrap(), "original");
+    }
+
+    #[test]
+    fn remove_pointer_block_strips_block_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("AGENTS.md");
+        fs::write(&p, "# Existing content\n").unwrap();
+        ensure_pointer_block(&p).unwrap();
+
+        let modified = remove_pointer_block(&p).unwrap();
+        assert!(modified);
+
+        let body = fs::read_to_string(&p).unwrap();
+        assert!(!body.contains(POINTER_START), "block should be removed");
+        assert!(
+            body.contains("# Existing content"),
+            "other content preserved"
+        );
+    }
+
+    #[test]
+    fn remove_pointer_block_no_op_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("AGENTS.md");
+        fs::write(&p, "# No carryover block here\n").unwrap();
+        let modified = remove_pointer_block(&p).unwrap();
+        assert!(!modified);
+    }
+
+    #[test]
+    fn remove_pointer_block_no_op_on_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("nonexistent.md");
+        let modified = remove_pointer_block(&p).unwrap();
+        assert!(!modified);
     }
 }


### PR DESCRIPTION
## Summary
- Codex has no per-session hook; carryover now uses two surfaces:
  1. `notify = ["~/.carryover/hooks/codex-notify.sh"]` in `~/.codex/config.toml` fires on each turn-end and POSTs to the daemon
  2. AGENTS.md pointer block stamped into `~/.codex/AGENTS.md`, `~/AGENTS.md`, and `~/CLAUDE.md` so Codex auto-reads the handoff on session start
- `toml_edit` preserves comments and unrelated keys through round-trips
- Adds `remove_pointer_block` to `publish::pointer` for uninstall cleanup
- Removes the "skipping codex hook stub write" placeholder (B3 fix)

## Test plan
- [ ] `cargo test` — all tests pass
- [ ] `carryoverd install` (with codex selected): `~/.codex/config.toml` gets `notify = ["~/.carryover/hooks/codex-notify.sh"]`, AGENTS.md pointer written to 3 locations
- [ ] `carryoverd uninstall`: notify entry removed, pointer blocks removed from AGENTS.md/CLAUDE.md
- [ ] Round-trip: existing config.toml with comments is preserved through install+uninstall
- [ ] End-to-end dogfood after all phases merge

## Note
This branch is from main and needs a rebase onto #43 (fix/B5-cursor-protocol) before merge, as both modify hooks_writer.rs.