### PR TITLE
fix(cursor): migrate old bare-string sessionStart entry on install/uninstall

### DIFF
--- a/src/cli/hooks_writer.rs
+++ b/src/cli/hooks_writer.rs
@@ -258,6 +258,15 @@ pub fn write_cursor_hooks(settings_path: &Path, hooks: &[(&str, &str)]) -> Resul
         _ => serde_json::Map::new(),
     };
     let mut modified = false;
+
+    // Migration: remove the old bare-string sessionStart entry written by v0.0.x.
+    if let Some(v) = map.get("sessionStart") {
+        if v.is_string() && v.as_str().map(|s| s.contains("carryover")).unwrap_or(false) {
+            map.remove("sessionStart");
+            modified = true;
+        }
+    }
+
     for (_tool, event) in hooks {
         let script = cursor_wrapper_path(&home, event);
         let script_str = script.to_string_lossy().into_owned();

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -41,7 +41,7 @@ pub fn run(purge: bool) -> Result<()> {
                 "PreCompact",
                 "UserPromptSubmit",
             ],
-            "cursor" => vec!["beforeSubmitPrompt", "stop"],
+            "cursor" => vec!["beforeSubmitPrompt", "stop", "sessionStart"],
             "codex" => vec![],
             _ => vec![],
         };


### PR DESCRIPTION
## Summary
- Old installs wrote `"sessionStart": "curl ..."` (bare string) to ~/.cursor/hooks.json
- The uninstall event list didn't include `sessionStart` so old entries weren't cleaned up
- `write_cursor_hooks` now removes the old bare-string entry on the next `install` or `refresh`
- `uninstall` now also passes `sessionStart` to `remove_cursor_hooks` so it removes legacy entries

## Test plan
- [ ] `cargo test` — all tests pass
- [ ] Fresh e2e: `carryoverd install` leaves no `sessionStart` key in hooks.json
- [ ] Upgrade e2e: after old-format install, `carryoverd refresh` removes the stale entry