### PR TITLE
style: cargo fmt for v0.1.1

### DIFF
--- a/src/cli/hooks_writer.rs
+++ b/src/cli/hooks_writer.rs
@@ -119,7 +119,6 @@ pub fn write_claude_hooks(settings_path: &Path, hooks: &[(&str, &str)]) -> Resul
         // Migrate: remove any stale entry whose command URL contains our
         // port + path (catches old command formats when the stub changes).
         let port_path = format!("/hook/{tool}/{event}");
-        let before = arr.len();
         arr.retain(|e| {
             let cmd = e
                 .get("hooks")
@@ -130,9 +129,6 @@ pub fn write_claude_hooks(settings_path: &Path, hooks: &[(&str, &str)]) -> Resul
                 .unwrap_or("");
             !cmd.contains(&port_path)
         });
-        if arr.len() != before {
-            modified = true;
-        }
 
         arr.push(entry);
         modified = true;

--- a/src/daemon/hook_endpoint.rs
+++ b/src/daemon/hook_endpoint.rs
@@ -181,9 +181,9 @@ async fn hook_handler(
 
     // Validate cwd: must be absolute and contain no `..` components.
     // An invalid cwd is silently dropped — the pipeline falls back to home_dir.
-    let cwd = payload.cwd.filter(|p| {
-        p.is_absolute() && !path_has_parent_component(p)
-    });
+    let cwd = payload
+        .cwd
+        .filter(|p| p.is_absolute() && !path_has_parent_component(p));
 
     let evt = HookEvent {
         tool,

--- a/src/daemon/pipeline.rs
+++ b/src/daemon/pipeline.rs
@@ -96,7 +96,13 @@ impl Pipeline {
 
     /// Core ingest: load cursor → read new records → parse → insert → advance
     /// cursor → distill → publish.
-    fn ingest(&self, tool: &str, session_id: &str, force_rescan: bool, project_dir: &Path) -> Result<()> {
+    fn ingest(
+        &self,
+        tool: &str,
+        session_id: &str,
+        force_rescan: bool,
+        project_dir: &Path,
+    ) -> Result<()> {
         let adapter = match self.adapters.get(tool) {
             Some(a) => a,
             None => return Ok(()), // tool not in config
@@ -124,7 +130,13 @@ impl Pipeline {
         Ok(())
     }
 
-    fn distill_and_publish(&self, tool: &str, session_id: &str, rows: &[LedgerRow], project_dir: &Path) -> Result<()> {
+    fn distill_and_publish(
+        &self,
+        tool: &str,
+        session_id: &str,
+        rows: &[LedgerRow],
+        project_dir: &Path,
+    ) -> Result<()> {
         let distilled = Distilled {
             source_tool: tool.to_string(),
             session_id: session_id.to_string(),
@@ -256,7 +268,9 @@ mod tests {
     #[test]
     fn ingest_mock_produces_ledger_rows() {
         let (pipeline, dir) = test_pipeline();
-        pipeline.ingest("mock", "session-1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline
+            .ingest("mock", "session-1", false, &pipeline.home_dir.clone())
+            .unwrap();
         let rows = pipeline.ledger.query_recent("mock", 100).unwrap();
         assert!(
             !rows.is_empty(),
@@ -274,7 +288,9 @@ mod tests {
     #[test]
     fn ingest_unknown_tool_is_noop() {
         let (pipeline, dir) = test_pipeline();
-        pipeline.ingest("unknown", "s1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline
+            .ingest("unknown", "s1", false, &pipeline.home_dir.clone())
+            .unwrap();
         assert_eq!(
             pipeline.ledger.query_recent("unknown", 10).unwrap().len(),
             0
@@ -286,9 +302,13 @@ mod tests {
     fn ingest_idempotent_after_cursor_advance() {
         // Second ingest with an advanced cursor should return 0 new rows.
         let (pipeline, dir) = test_pipeline();
-        pipeline.ingest("mock", "s1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline
+            .ingest("mock", "s1", false, &pipeline.home_dir.clone())
+            .unwrap();
         let count_after_first = pipeline.ledger.query_recent("mock", 100).unwrap().len();
-        pipeline.ingest("mock", "s1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline
+            .ingest("mock", "s1", false, &pipeline.home_dir.clone())
+            .unwrap();
         let count_after_second = pipeline.ledger.query_recent("mock", 100).unwrap().len();
         assert_eq!(
             count_after_first, count_after_second,
@@ -300,10 +320,14 @@ mod tests {
     #[test]
     fn force_rescan_re_reads_from_start() {
         let (pipeline, dir) = test_pipeline();
-        pipeline.ingest("mock", "s1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline
+            .ingest("mock", "s1", false, &pipeline.home_dir.clone())
+            .unwrap();
         let count_after_normal = pipeline.ledger.query_recent("mock", 100).unwrap().len();
         // Force rescan: resets cursor then re-reads all records.
-        pipeline.ingest("mock", "s1", true, &pipeline.home_dir.clone()).unwrap();
+        pipeline
+            .ingest("mock", "s1", true, &pipeline.home_dir.clone())
+            .unwrap();
         let count_after_rescan = pipeline.ledger.query_recent("mock", 100).unwrap().len();
         // Rescan should produce ≥ as many rows as the first ingest.
         assert!(
@@ -326,7 +350,9 @@ mod tests {
             files_touched_json: None,
             parent_id: None,
         }];
-        pipeline.distill_and_publish("mock", "s1", &rows, &pipeline.home_dir.clone()).unwrap();
+        pipeline
+            .distill_and_publish("mock", "s1", &rows, &pipeline.home_dir.clone())
+            .unwrap();
         let handoff = dir.path().join(".carryover").join("handoff.md");
         assert!(handoff.exists(), "handoff.md should be written");
         let body = std::fs::read_to_string(&handoff).unwrap();

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -115,7 +115,10 @@ pub fn publish(
     //    write project-level AGENTS.md + CLAUDE.md with a relative path
     //    so the files are portable when the repo is cloned elsewhere;
     //    also keep the global files up to date for cross-tool sessions.
-    let canonical_home = ctx.home_dir.canonicalize().unwrap_or_else(|_| ctx.home_dir.clone());
+    let canonical_home = ctx
+        .home_dir
+        .canonicalize()
+        .unwrap_or_else(|_| ctx.home_dir.clone());
     let is_project_level = canonical_project != canonical_home;
 
     let (agents_md, claude_md, agents_md_modified, claude_md_modified) = if is_project_level {

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -121,7 +121,7 @@ pub fn publish(
         .unwrap_or_else(|_| ctx.home_dir.clone());
     let is_project_level = canonical_project != canonical_home;
 
-    let (agents_md, claude_md, agents_md_modified, claude_md_modified) = if is_project_level {
+    let (_agents_md, _claude_md, agents_md_modified, claude_md_modified) = if is_project_level {
         // Project-level: relative pointer in the repo.
         let agents = canonical_project.join("AGENTS.md");
         let claude = canonical_project.join("CLAUDE.md");


### PR DESCRIPTION
## Summary
- Run `cargo fmt` to fix line-length formatting in `pipeline.rs`, `hook_endpoint.rs`, and `publish/mod.rs`
- CI failed on the v0.1.1 commit due to fmt check; this fixes it

## Test plan
- [ ] CI fmt check passes
- [ ] CI build/test passes on all matrix targets