### PR TITLE
revert: undo direct push of v0.1.1 (failed CI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,3 @@ LAUNCH_CHECKLIST.md
 
 # Python bytecode caches under tests/
 __pycache__/
-.carryover/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,3 @@ cargo build --release                            # produces ./target/release/car
 cargo fmt --check
 cargo clippy --all-targets -- -D warnings
 ```
-
-<!--CARRYOVER:START-->
-Carryover is active. Before responding:
-1. Read `.carryover/handoff.md` for the prior session summary.
-2. Summarize it back to the user in 1-2 sentences.
-3. Ask what they want to do next — do not assume continuation.
-<!--CARRYOVER:END-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once v0.1.0 ships.
 
-## 0.1.1 — 2026-04-28
-
-### Fixed
-
-- Cursor: inject handoff content directly via `beforeSubmitPrompt` stdout `context` field — AI models inside Cursor don't have a filesystem read tool, so the AGENTS.md pointer alone was silent.
-- Cursor: per-project injection flag (`$PWD/.carryover/cursor-injected`) so switching between projects each gets a fresh inject; stop hook clears both project and global flags.
-- Cursor/Codex hooks: send `$PWD` as `cwd` in hook payload so daemon writes project-level `<project>/.carryover/handoff.md` alongside the global `~/.carryover/handoff.md`.
-- Pointer block: embed absolute `~/.carryover/handoff.md` path in global `~/AGENTS.md` / `~/CLAUDE.md`; use relative `.carryover/handoff.md` only in project-level files.
-- Hook migration: detect and replace stale hook entries by port+path match so old format is cleanly upgraded on `refresh`.
-
 ## 0.1.0 — 2026-04-28
 
 First public release. Working cross-tool context-handoff between Claude Code, Cursor, and Codex on Linux. macOS support documented in release notes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,0 @@
-<!--CARRYOVER:START-->
-Carryover is active. Before responding:
-1. Read `.carryover/handoff.md` for the prior session summary.
-2. Summarize it back to the user in 1-2 sentences.
-3. Ask what they want to do next — do not assume continuation.
-<!--CARRYOVER:END-->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "carryover"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carryover"
-version = "0.1.1"
+version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Zero-LLM-token context-handoff daemon — resume any AI session across Claude Code, Cursor, and Codex."

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carryover",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Zero-LLM-token context-handoff daemon — resume any AI session across Claude Code, Cursor, and Codex.",
   "homepage": "https://github.com/carryover-dev/carryover",
   "repository": {

--- a/src/cli/hooks_writer.rs
+++ b/src/cli/hooks_writer.rs
@@ -19,7 +19,7 @@ use crate::daemon::hook_endpoint::LOOPBACK_PORT;
 /// Return the canonical curl stub command for a (tool, event) pair.
 pub fn curl_stub(tool: &str, event: &str) -> String {
     format!(
-        "curl -X POST -s -H 'Content-Type: application/json' -d \"{{\\\"cwd\\\":\\\"$PWD\\\"}}\" http://127.0.0.1:{LOOPBACK_PORT}/hook/{tool}/{event} > /dev/null 2>&1 &"
+        "curl -X POST -s -H 'Content-Type: application/json' -d '{{}}' http://127.0.0.1:{LOOPBACK_PORT}/hook/{tool}/{event} > /dev/null 2>&1 &"
     )
 }
 
@@ -214,40 +214,9 @@ pub fn cursor_wrapper_path(home: &Path, event: &str) -> std::path::PathBuf {
 }
 
 fn cursor_wrapper_script(tool: &str, event: &str) -> String {
-    let curl = format!(
-        "curl -X POST -s -H 'Content-Type: application/json' \\\n  -d \"{{\\\"cwd\\\":\\\"$PWD\\\"}}\" http://127.0.0.1:{LOOPBACK_PORT}/hook/{tool}/{event} > /dev/null 2>&1 &"
-    );
-    match event {
-        "beforeSubmitPrompt" => format!(
-            "#!/usr/bin/env sh\n\
-             INPUT=$(cat)\n\
-             {curl}\n\
-             if [ -f \"$PWD/.carryover/handoff.md\" ]; then\n\
-             HANDOFF=\"$PWD/.carryover/handoff.md\"\n\
-             FLAG=\"$PWD/.carryover/cursor-injected\"\n\
-             else\n\
-             HANDOFF=\"$HOME/.carryover/handoff.md\"\n\
-             FLAG=\"$HOME/.carryover/cursor-injected\"\n\
-             fi\n\
-             if [ ! -f \"$FLAG\" ] && [ -f \"$HANDOFF\" ]; then\n\
-             touch \"$FLAG\"\n\
-             printf '{{\"context\":%s}}' \"$(python3 -c \"import json,sys; print(json.dumps(sys.stdin.read()),end='')\" < \"$HANDOFF\")\"\n\
-             else\n\
-             printf '{{}}'\n\
-             fi\n"
-        ),
-        "stop" => format!(
-            "#!/usr/bin/env sh\n\
-             INPUT=$(cat)\n\
-             {curl}\n\
-             rm -f \"$PWD/.carryover/cursor-injected\"\n\
-             rm -f \"$HOME/.carryover/cursor-injected\"\n\
-             printf '{{}}'\n"
-        ),
-        _ => format!(
-            "#!/usr/bin/env sh\nINPUT=$(cat)\n{curl}\nprintf '{{}}'\n"
-        ),
-    }
+    format!(
+        "#!/usr/bin/env sh\nINPUT=$(cat)\ncurl -X POST -s -H 'Content-Type: application/json' \\\n  -d \"$INPUT\" http://127.0.0.1:{LOOPBACK_PORT}/hook/{tool}/{event} > /dev/null 2>&1\nprintf '{{}}'\n"
+    )
 }
 
 /// Write wrapper scripts for all Cursor hook events to `~/.carryover/hooks/`.
@@ -402,7 +371,7 @@ pub fn codex_wrapper_path(home: &Path) -> std::path::PathBuf {
 
 fn codex_wrapper_script() -> String {
     format!(
-        "#!/usr/bin/env sh\nINPUT=$(cat)\ncurl -X POST -s -H 'Content-Type: application/json' \\\n  -d \"{{\\\"cwd\\\":\\\"$PWD\\\"}}\" http://127.0.0.1:{LOOPBACK_PORT}/hook/codex/turnEnd > /dev/null 2>&1\n"
+        "#!/usr/bin/env sh\nINPUT=$(cat)\ncurl -X POST -s -H 'Content-Type: application/json' \\\n  -d \"$INPUT\" http://127.0.0.1:{LOOPBACK_PORT}/hook/codex/turnEnd > /dev/null 2>&1\n"
     )
 }
 
@@ -612,7 +581,7 @@ mod tests {
         let s = curl_stub("claude", "SessionStart");
         assert_eq!(
             s,
-            "curl -X POST -s -H 'Content-Type: application/json' -d \"{\\\"cwd\\\":\\\"$PWD\\\"}\" http://127.0.0.1:47823/hook/claude/SessionStart > /dev/null 2>&1 &"
+            "curl -X POST -s -H 'Content-Type: application/json' -d '{}' http://127.0.0.1:47823/hook/claude/SessionStart > /dev/null 2>&1 &"
         );
     }
 
@@ -828,22 +797,10 @@ mod tests {
             prompt_content.contains("/hook/cursor/beforeSubmitPrompt"),
             "prompt script must POST to beforeSubmitPrompt endpoint"
         );
-        assert!(
-            prompt_content.contains("cursor-injected"),
-            "prompt script must use injection flag"
-        );
-        assert!(
-            prompt_content.contains("context"),
-            "prompt script must emit context field"
-        );
         let stop_content = std::fs::read_to_string(&stop_script).unwrap();
         assert!(
             stop_content.contains("/hook/cursor/stop"),
             "stop script must POST to stop endpoint"
-        );
-        assert!(
-            stop_content.contains("cursor-injected"),
-            "stop script must clear injection flag"
         );
         assert!(
             !p.exists(),

--- a/src/daemon/hook_endpoint.rs
+++ b/src/daemon/hook_endpoint.rs
@@ -68,10 +68,6 @@ pub struct HookEvent {
     pub event: String,
     pub transcript_path: Option<PathBuf>,
     pub session_id: Option<String>,
-    /// Working directory of the AI tool process that fired the hook.
-    /// Used by the pipeline to write a per-project handoff alongside the
-    /// global `~/.carryover/handoff.md`.
-    pub cwd: Option<PathBuf>,
     /// Tool-specific extra metadata (kept opaque so the schema can grow per tool).
     #[serde(default, flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
@@ -83,7 +79,6 @@ pub struct HookEvent {
 pub struct HookPayload {
     pub transcript_path: Option<PathBuf>,
     pub session_id: Option<String>,
-    pub cwd: Option<PathBuf>,
     #[serde(default, flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
@@ -179,18 +174,11 @@ async fn hook_handler(
         other => other,
     };
 
-    // Validate cwd: must be absolute and contain no `..` components.
-    // An invalid cwd is silently dropped — the pipeline falls back to home_dir.
-    let cwd = payload.cwd.filter(|p| {
-        p.is_absolute() && !path_has_parent_component(p)
-    });
-
     let evt = HookEvent {
         tool,
         event,
         transcript_path,
         session_id: payload.session_id,
-        cwd,
         extra: payload.extra,
     };
     // UnboundedSender::send only fails when the receiver is dropped (channel closed).
@@ -305,7 +293,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hook_event_cwd_parsed_and_extra_fields_preserved() {
+    async fn hook_event_extra_fields_preserved() {
         let (app, mut rx) = make_router();
         app.oneshot(loopback_req(
             "POST",
@@ -316,24 +304,8 @@ mod tests {
         .unwrap();
 
         let evt = rx.try_recv().expect("hook event must be queued");
-        // cwd is now a first-class field, not in extra.
-        assert_eq!(evt.cwd, Some(PathBuf::from("/synthetic/path/1")));
+        assert_eq!(evt.extra.get("cwd").unwrap(), "/synthetic/path/1");
         assert_eq!(evt.extra.get("version").unwrap(), "2.0.0");
-    }
-
-    #[tokio::test]
-    async fn hook_event_cwd_with_traversal_is_dropped() {
-        let (app, mut rx) = make_router();
-        app.oneshot(loopback_req(
-            "POST",
-            "/hook/claude/PreCompact",
-            Body::from(r#"{"cwd": "/tmp/../etc"}"#),
-        ))
-        .await
-        .unwrap();
-
-        let evt = rx.try_recv().expect("hook event must be queued");
-        assert_eq!(evt.cwd, None, "traversal cwd should be dropped");
     }
 
     #[tokio::test]

--- a/src/daemon/pipeline.rs
+++ b/src/daemon/pipeline.rs
@@ -55,15 +55,7 @@ impl Pipeline {
             .session_id
             .clone()
             .unwrap_or_else(|| "default".to_string());
-        // Use the hook's cwd as project_dir if it's a real existing directory;
-        // fall back to home_dir when absent or nonexistent.
-        let project_dir = evt
-            .cwd
-            .as_ref()
-            .filter(|p| p.is_dir())
-            .cloned()
-            .unwrap_or_else(|| self.home_dir.clone());
-        if let Err(e) = self.ingest(&evt.tool, &session_id, false, &project_dir) {
+        if let Err(e) = self.ingest(&evt.tool, &session_id, false) {
             self.log_error(&evt.tool, &session_id, &format!("{e:#}"));
         }
     }
@@ -85,10 +77,8 @@ impl Pipeline {
 
         // Ingest all configured adapters — each adapter reads from its own
         // paths and returns nothing if those paths haven't changed.
-        // fs-watch events don't carry a cwd, so use home_dir as project_dir.
-        let project_dir = self.home_dir.clone();
         for tool in self.adapters.keys() {
-            if let Err(e) = self.ingest(tool, "default", evt.rescan, &project_dir) {
+            if let Err(e) = self.ingest(tool, "default", evt.rescan) {
                 self.log_error(tool, "default", &format!("{e:#}"));
             }
         }
@@ -96,7 +86,7 @@ impl Pipeline {
 
     /// Core ingest: load cursor → read new records → parse → insert → advance
     /// cursor → distill → publish.
-    fn ingest(&self, tool: &str, session_id: &str, force_rescan: bool, project_dir: &Path) -> Result<()> {
+    fn ingest(&self, tool: &str, session_id: &str, force_rescan: bool) -> Result<()> {
         let adapter = match self.adapters.get(tool) {
             Some(a) => a,
             None => return Ok(()), // tool not in config
@@ -120,11 +110,11 @@ impl Pipeline {
         self.ledger
             .save_cursor(tool, session_id, &new_cursor_json)?;
 
-        self.distill_and_publish(tool, session_id, &rows, project_dir)?;
+        self.distill_and_publish(tool, session_id, &rows)?;
         Ok(())
     }
 
-    fn distill_and_publish(&self, tool: &str, session_id: &str, rows: &[LedgerRow], project_dir: &Path) -> Result<()> {
+    fn distill_and_publish(&self, tool: &str, session_id: &str, rows: &[LedgerRow]) -> Result<()> {
         let distilled = Distilled {
             source_tool: tool.to_string(),
             session_id: session_id.to_string(),
@@ -139,7 +129,9 @@ impl Pipeline {
 
         let ctx = PublishContext {
             home_dir: self.home_dir.clone(),
-            project_dir: project_dir.to_path_buf(),
+            // v0.1: write to home dir (global handoff).
+            // Per-project dir requires CWD in hook payload — future PR.
+            project_dir: self.home_dir.clone(),
             resume_mode: self.resume_mode.clone(),
         };
 
@@ -256,7 +248,7 @@ mod tests {
     #[test]
     fn ingest_mock_produces_ledger_rows() {
         let (pipeline, dir) = test_pipeline();
-        pipeline.ingest("mock", "session-1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline.ingest("mock", "session-1", false).unwrap();
         let rows = pipeline.ledger.query_recent("mock", 100).unwrap();
         assert!(
             !rows.is_empty(),
@@ -274,7 +266,7 @@ mod tests {
     #[test]
     fn ingest_unknown_tool_is_noop() {
         let (pipeline, dir) = test_pipeline();
-        pipeline.ingest("unknown", "s1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline.ingest("unknown", "s1", false).unwrap();
         assert_eq!(
             pipeline.ledger.query_recent("unknown", 10).unwrap().len(),
             0
@@ -286,9 +278,9 @@ mod tests {
     fn ingest_idempotent_after_cursor_advance() {
         // Second ingest with an advanced cursor should return 0 new rows.
         let (pipeline, dir) = test_pipeline();
-        pipeline.ingest("mock", "s1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline.ingest("mock", "s1", false).unwrap();
         let count_after_first = pipeline.ledger.query_recent("mock", 100).unwrap().len();
-        pipeline.ingest("mock", "s1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline.ingest("mock", "s1", false).unwrap();
         let count_after_second = pipeline.ledger.query_recent("mock", 100).unwrap().len();
         assert_eq!(
             count_after_first, count_after_second,
@@ -300,10 +292,10 @@ mod tests {
     #[test]
     fn force_rescan_re_reads_from_start() {
         let (pipeline, dir) = test_pipeline();
-        pipeline.ingest("mock", "s1", false, &pipeline.home_dir.clone()).unwrap();
+        pipeline.ingest("mock", "s1", false).unwrap();
         let count_after_normal = pipeline.ledger.query_recent("mock", 100).unwrap().len();
         // Force rescan: resets cursor then re-reads all records.
-        pipeline.ingest("mock", "s1", true, &pipeline.home_dir.clone()).unwrap();
+        pipeline.ingest("mock", "s1", true).unwrap();
         let count_after_rescan = pipeline.ledger.query_recent("mock", 100).unwrap().len();
         // Rescan should produce ≥ as many rows as the first ingest.
         assert!(
@@ -326,7 +318,7 @@ mod tests {
             files_touched_json: None,
             parent_id: None,
         }];
-        pipeline.distill_and_publish("mock", "s1", &rows, &pipeline.home_dir.clone()).unwrap();
+        pipeline.distill_and_publish("mock", "s1", &rows).unwrap();
         let handoff = dir.path().join(".carryover").join("handoff.md");
         assert!(handoff.exists(), "handoff.md should be written");
         let body = std::fs::read_to_string(&handoff).unwrap();
@@ -346,7 +338,6 @@ mod tests {
             event: "SessionEnd".to_string(),
             transcript_path: None,
             session_id: Some("hook-session".to_string()),
-            cwd: None,
             extra: serde_json::Map::new(),
         };
         pipeline.process_hook(&evt);

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -21,8 +21,7 @@ mod write_atomic;
 
 pub use handoff::{render_handoff, Distilled, MAX_HANDOFF_LINES};
 pub use pointer::{
-    ensure_pointer_block, ensure_pointer_block_relative, pointer_block, remove_pointer_block,
-    POINTER_END, POINTER_START,
+    ensure_pointer_block, pointer_block, remove_pointer_block, POINTER_END, POINTER_START,
 };
 
 use std::path::{Path, PathBuf};
@@ -106,36 +105,12 @@ pub fn publish(
     let project_bytes = std::fs::read(&project_handoff)?;
     assert_eq!(user_bytes, project_bytes, "dual-write divergence");
 
-    // STEP 4. Pointer blocks in AGENTS.md and CLAUDE.md.
-    //
-    // Two cases:
-    // a) project_dir == home_dir (v0.1 fallback, no CWD from hook) →
-    //    write global ~/AGENTS.md + ~/CLAUDE.md with an absolute path.
-    // b) project_dir is a real project dir (v0.2, CWD present in hook) →
-    //    write project-level AGENTS.md + CLAUDE.md with a relative path
-    //    so the files are portable when the repo is cloned elsewhere;
-    //    also keep the global files up to date for cross-tool sessions.
-    let canonical_home = ctx.home_dir.canonicalize().unwrap_or_else(|_| ctx.home_dir.clone());
-    let is_project_level = canonical_project != canonical_home;
-
-    let (agents_md, claude_md, agents_md_modified, claude_md_modified) = if is_project_level {
-        // Project-level: relative pointer in the repo.
-        let agents = canonical_project.join("AGENTS.md");
-        let claude = canonical_project.join("CLAUDE.md");
-        let a = pointer::ensure_pointer_block_relative(&agents)?;
-        let c = pointer::ensure_pointer_block_relative(&claude)?;
-        // Keep the global files updated too (absolute pointer).
-        let _ = pointer::ensure_pointer_block(&ctx.home_dir.join("AGENTS.md"));
-        let _ = pointer::ensure_pointer_block(&ctx.home_dir.join("CLAUDE.md"));
-        (agents, claude, a, c)
-    } else {
-        // Global fallback (home_dir): absolute pointer.
-        let agents = canonical_project.join("AGENTS.md");
-        let claude = canonical_project.join("CLAUDE.md");
-        let a = pointer::ensure_pointer_block(&agents)?;
-        let c = pointer::ensure_pointer_block(&claude)?;
-        (agents, claude, a, c)
-    };
+    // STEP 4. Pointer block in AGENTS.md and CLAUDE.md (byte-identical,
+    // atomic, symlink-rejected).
+    let agents_md = canonical_project.join("AGENTS.md");
+    let claude_md = canonical_project.join("CLAUDE.md");
+    let agents_md_modified = pointer::ensure_pointer_block(&agents_md)?;
+    let claude_md_modified = pointer::ensure_pointer_block(&claude_md)?;
 
     Ok(PublishOutcome {
         user_handoff,

--- a/src/publish/pointer.rs
+++ b/src/publish/pointer.rs
@@ -55,13 +55,6 @@ pub fn ensure_pointer_block(path: &Path) -> std::io::Result<bool> {
     ensure_pointer_block_with_path(path, &handoff_path)
 }
 
-/// Insert the pointer block using a relative `.carryover/handoff.md` path.
-/// Use this for project-level AGENTS.md / CLAUDE.md that live inside the repo;
-/// the relative path resolves correctly from any checkout location.
-pub fn ensure_pointer_block_relative(path: &Path) -> std::io::Result<bool> {
-    ensure_pointer_block_with_path(path, Path::new(".carryover/handoff.md"))
-}
-
 /// Like `ensure_pointer_block` but with an explicit handoff path (used in tests
 /// and by the per-project publish path in future versions).
 pub fn ensure_pointer_block_with_path(path: &Path, handoff_path: &Path) -> std::io::Result<bool> {

--- a/tests/cross_tool.rs
+++ b/tests/cross_tool.rs
@@ -17,6 +17,8 @@
 
 use std::path::{Path, PathBuf};
 
+use dirs;
+
 use carryover::adapters::{
     self, claude::ClaudeAdapter, codex::CodexAdapter, cursor::CursorAdapter, Adapter,
 };
@@ -182,8 +184,12 @@ fn run_pipeline(source_tool: &str) {
         extract_block(&claude),
         "{source_tool}: pointer block must be byte-identical across AGENTS.md and CLAUDE.md"
     );
-    // project != home → relative pointer in project files
-    let expected_block = pointer_block(std::path::Path::new(".carryover/handoff.md"));
+    let expected_block = pointer_block(
+        &dirs::home_dir()
+            .unwrap()
+            .join(".carryover")
+            .join("handoff.md"),
+    );
     assert_eq!(
         extract_block(&agents),
         expected_block,


### PR DESCRIPTION
## Summary
- Reverts commit 40e45c1 which was pushed directly to main, bypassing branch protection
- That commit failed CI (cargo fmt check)
- The v0.1.1 changes will land cleanly via PR #47 once this merges

## Test plan
- [ ] CI passes (reverts to known-good state at e62e595)