### PR TITLE
fix: use macos-14 for both macOS release targets (macos-13 deprecated)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,15 +97,15 @@ jobs:
 
   build-macos:
     name: Build (${{ matrix.target }})
-    runs-on: ${{ matrix.runner }}
+    # macos-13 is GitHub-deprecated with unreliable runner availability.
+    # Both targets build on macos-14 (arm64); x86_64 is a cross-compile.
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin
-            runner: macos-14
           - target: x86_64-apple-darwin
-            runner: macos-13
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary
- Both `aarch64-apple-darwin` and `x86_64-apple-darwin` now build on `macos-14`
- `x86_64-apple-darwin` is cross-compiled from the arm64 runner (same pattern as ci.yml)
- Removes dependency on `macos-13` which has unreliable runner availability

## Test plan
- [ ] Merge and re-tag v0.1.2 — both macOS targets should build and appear in release